### PR TITLE
Prevent text selection when resizing the devtools container

### DIFF
--- a/packages/devtools/src/styles/use-styles.ts
+++ b/packages/devtools/src/styles/use-styles.ts
@@ -90,6 +90,7 @@ const stylesFactory = () => {
       width: 100%;
       height: 4px;
       cursor: row-resize;
+      user-select: none;
       z-index: 100000;
       &:hover {
         background-color: ${colors.purple[400]}${alpha[90]};


### PR DESCRIPTION
This PR fixes a small issue where the browser tries to select text underneath the floating panel while resizing it. Adding `user-select: none` to the drag handle fixes the issue.


https://github.com/user-attachments/assets/120a64c2-f294-4b6c-a1d0-73d6a2577633

