### PR TITLE
fix: allow the `config` prop to only contain some of the config

### DIFF
--- a/packages/react-devtools/src/devtools.tsx
+++ b/packages/react-devtools/src/devtools.tsx
@@ -82,7 +82,7 @@ export interface TanStackDevtoolsReactInit {
    * initial state of the devtools when it is started for the first time. Afterwards,
    * the settings are persisted in local storage and changed through the settings panel.
    */
-  config?: TanStackDevtoolsConfig
+  config?: Partial<TanStackDevtoolsConfig>
 }
 
 const convertRender = (


### PR DESCRIPTION
It is merged with the initial settings from the store, so the user can only provide the settings they want to override.