### PR TITLE
fix: plugin ID generation to include index when using the plugin name

### DIFF
--- a/packages/devtools/src/context/devtools-context.tsx
+++ b/packages/devtools/src/context/devtools-context.tsx
@@ -85,7 +85,7 @@ const generatePluginId = (plugin: TanStackDevtoolsPlugin, index: number) => {
   }
   if (typeof plugin.name === 'string') {
     // if name is a string, use it to generate an id
-    return plugin.name.toLowerCase().replace(' ', '-')
+    return `${plugin.name.toLowerCase().replace(' ', '-')}-${index}`
   }
   // Name is JSX? return the index as a string
   return index.toString()


### PR DESCRIPTION
If two plugins share the same name, they currently receive the same `id`, which causes both to activate when you click on either one in the sidebar.