### PR TITLE
fix: web components now work in React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,10 @@
     "@tanstack/devtools": "workspace:*",
     "@tanstack/react-devtools": "workspace:*",
     "@tanstack/solid-devtools": "workspace:*"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "component-register": "patches/component-register.patch"
+    }
   }
 }

--- a/patches/component-register.patch
+++ b/patches/component-register.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/component-register.js b/dist/component-register.js
+index 726c10dabade8ebd316021f4bd8d7e84c0995dea..2a34321e30ece9fa343e3cb2e6874eb0bbe4a815 100644
+--- a/dist/component-register.js
++++ b/dist/component-register.js
+@@ -118,6 +118,9 @@ function createElementType(BaseElement, propDefinition) {
+       this.__propertyChangedCallbacks = [];
+       this.__updating = {};
+       this.props = {};
++      for (let propKey of propKeys) {
++        this[propKey] = undefined
++      }
+     }
+     connectedCallback() {
+       if (this.__initialized) return;
+diff --git a/lib/component-register.js b/lib/component-register.js
+index a06bc4928fa96d74725c7a63387b3abcd1276eea..09698d85764b9157fde3708039bbefec370362aa 100644
+--- a/lib/component-register.js
++++ b/lib/component-register.js
+@@ -122,6 +122,9 @@ function createElementType(BaseElement, propDefinition) {
+       this.__propertyChangedCallbacks = [];
+       this.__updating = {};
+       this.props = {};
++      for (let propKey of propKeys) {
++        this[propKey] = undefined
++      }
+     }
+     connectedCallback() {
+       if (this.__initialized) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  component-register:
+    hash: 77e26fa4f81b0d3b9f3df77c90412c841c06cacf9b9c46a409b26e2815cbe4f7
+    path: patches/component-register.patch
+
 importers:
 
   .:
@@ -236,8 +241,6 @@ importers:
       web-vitals:
         specifier: ^4.2.4
         version: 4.2.4
-
-  examples/react/start/generated/prisma: {}
 
   examples/react/time-travel:
     dependencies:
@@ -10526,7 +10529,7 @@ snapshots:
 
   compatx@0.2.0: {}
 
-  component-register@0.8.7: {}
+  component-register@0.8.7(patch_hash=77e26fa4f81b0d3b9f3df77c90412c841c06cacf9b9c46a409b26e2815cbe4f7): {}
 
   compress-commons@6.0.2:
     dependencies:
@@ -13327,7 +13330,7 @@ snapshots:
 
   solid-element@1.9.1(solid-js@1.9.7):
     dependencies:
-      component-register: 0.8.7
+      component-register: 0.8.7(patch_hash=77e26fa4f81b0d3b9f3df77c90412c841c06cacf9b9c46a409b26e2815cbe4f7)
       solid-js: 1.9.7
 
   solid-js@1.9.7:


### PR DESCRIPTION
This PR merges https://github.com/ryansolid/component-register/pull/36/files into our project via `pnpm patch`. Just `pnpm i` and it'll work locally