### PR TITLE
fix: use location.origin; remove localhost hardcoding

### DIFF
--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -119,15 +119,6 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           }),
         )
       },
-      transform(code) {
-        if (code.includes('__TSD_PORT__')) {
-          code = code.replace('__TSD_PORT__', String(port))
-        }
-        if (code.includes('__TSD_HOST__')) {
-          code = code.replace('__TSD_HOST__', host)
-        }
-        return code
-      },
     },
     {
       name: '@tanstack/devtools:better-console-logs',

--- a/packages/devtools/src/devtools.tsx
+++ b/packages/devtools/src/devtools.tsx
@@ -174,7 +174,9 @@ export default function DevTools() {
           e.preventDefault()
           e.stopPropagation()
           fetch(
-            `__TSD_HOST__://localhost:__TSD_PORT__/__tsd/open-source?source=${encodeURIComponent(dataSource)}`,
+            `${location.origin}/__tsd/open-source?source=${encodeURIComponent(
+              dataSource,
+            )}`,
           ).catch(() => {})
         }
       }


### PR DESCRIPTION
I was using tanstack devtools on my local machine. During my project, some of my logic depended on hostname, so I usually develop using custom domains. 

The tools started to break and I investigated and noticed that localhost was hardcoded. 

DevTools hardcoded http://localhost:<port> for open-in-editor and related links, which broke in my setup where I routinely develop on custom domains/non-loopback hosts (and also impacts IPv6/HTTPS). 
This PR replaces the hardcoded origin with location.origin so links respect the actual scheme/host/port in use; it fixed the failures I observed while keeping localhost behavior intact. 

If this direction makes sense, I’m happy to add tests to prevent regressions.
