### PR TITLE
fix: update broken links in documents

### DIFF
--- a/docs/framework/react/basic-setup.md
+++ b/docs/framework/react/basic-setup.md
@@ -74,6 +74,6 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
-Finally add any additional configuration you desire to the `TanStackDevtools` component, more information can be found under the [TanStack Devtools Configuration](../../configuration.md) section.
+Finally add any additional configuration you desire to the `TanStackDevtools` component, more information can be found under the [TanStack Devtools Configuration](../../../configuration.md) section.
 
 A complete working example can be found in our [basic example](https://tanstack.com/devtools/latest/docs/framework/react/examples/basic).

--- a/docs/framework/react/guides/custom-plugins.md
+++ b/docs/framework/react/guides/custom-plugins.md
@@ -134,7 +134,7 @@ export function DevtoolPanel() {
 
 ## Application Integration
 
-This step follows what's shown in [basic-setup](../basic-setup.md)  for a more documented guide go check it out. As well as the complete [custom-devtools example](https://tanstack.com/devtools/latest/docs/framework/react/examples/custom-devtools) in our examples section.
+This step follows what's shown in [basic-setup](../../basic-setup.md)  for a more documented guide go check it out. As well as the complete [custom-devtools example](https://tanstack.com/devtools/latest/docs/framework/react/examples/custom-devtools) in our examples section.
 
 Main.tsx
 ```tsx

--- a/docs/framework/solid/adapter.md
+++ b/docs/framework/solid/adapter.md
@@ -1,6 +1,6 @@
 ---
 title: TanStack Devtools Solid Adapter
-ref: adapter
+id: adapter
 ---
 
 If you are using TanStack Devtools in a Solid application, we recommend using the Solid Adapter. The Solid Adapter provides a set of easy-to-use hooks on top of the core Devtools utilities. If you find yourself wanting to use the core Devtools classes/functions directly, the Solid Adapter will also re-export everything from the core package.

--- a/docs/framework/solid/basic-setup.md
+++ b/docs/framework/solid/basic-setup.md
@@ -68,6 +68,6 @@ render(() => (
 ), document.getElementById('root')!);
 ```
 
-Finally add any additional configuration you desire to the `TanStackDevtools` component, more information can be found under the [TanStack Devtools Configuration](https://tanstack.com/devtools/) section.
+Finally add any additional configuration you desire to the `TanStackDevtools` component, more information can be found under the [TanStack Devtools Configuration](../../../configuration.md) section.
 
 A complete working example can be found in our [examples section](https://tanstack.com/devtools/latest/docs/framework/solid/examples).


### PR DESCRIPTION
I'm delighted to be able to contribute to such a great project. Thank you.

### Changes

Releated issue: https://github.com/TanStack/devtools/issues/140

Resolves the issue where some links in the [TanStack Devtools documentation](https://tanstack.com/devtools/latest/docs/overview) were broken.

Testing for the updated link was conducted by referring to the README at tanstack.com below.
- https://github.com/TanStack/tanstack.com/blob/main/README.md