### PR TITLE
fix: apply missing ) to DevtoolsPanel example code

### DIFF
--- a/docs/framework/react/guides/custom-plugins.md
+++ b/docs/framework/react/guides/custom-plugins.md
@@ -121,7 +121,7 @@ export function DevtoolPanel() {
 
   useEffect(() => {
     // subscribe to the emitted event
-    const cleanup = DevtoolsEventClient.on("counter-state", e => setState(e.payload)
+    const cleanup = DevtoolsEventClient.on("counter-state", e => setState(e.payload))
     return cleanup
   }, [])
 
@@ -129,7 +129,7 @@ export function DevtoolPanel() {
     <div>
       <div>{state.count}</div>
       <div>{JSON.stringify(state.history)}</div>
-    <div/>
+    </div>
   )
 }
 ```


### PR DESCRIPTION
## 🎯 Changes

Fixes: #186 

The custom plugin documentation contains the following typo:
- jsx closed typo in DevtoolsPanel.ts example code
- on method `)` missing in DevtoolsPanel.ts example code

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
