### PR TITLE
fix: fix import.meta compatibility issue in rsbuild

### DIFF
--- a/.changeset/soft-peas-turn.md
+++ b/.changeset/soft-peas-turn.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools': patch
+---
+
+fix import.meta usage in rsbuild

--- a/packages/devtools/src/context/pip-context.tsx
+++ b/packages/devtools/src/context/pip-context.tsx
@@ -77,39 +77,39 @@ export const PiPProvider = (props: PiPProviderProps) => {
       closePipWindow()
     })
 
-      // It is important to copy all parent window styles. Otherwise, there would be no CSS available at all
-      // https://developer.chrome.com/docs/web-platform/document-picture-in-picture/#copy-style-sheets-to-the-picture-in-picture-window
-      ;[...document.styleSheets].forEach((styleSheet) => {
-        try {
-          const cssRules = [...styleSheet.cssRules]
-            .map((rule) => rule.cssText)
-            .join('')
-          const style = document.createElement('style')
-          const style_node = styleSheet.ownerNode
-          let style_id = ''
+    // It is important to copy all parent window styles. Otherwise, there would be no CSS available at all
+    // https://developer.chrome.com/docs/web-platform/document-picture-in-picture/#copy-style-sheets-to-the-picture-in-picture-window
+    ;[...document.styleSheets].forEach((styleSheet) => {
+      try {
+        const cssRules = [...styleSheet.cssRules]
+          .map((rule) => rule.cssText)
+          .join('')
+        const style = document.createElement('style')
+        const style_node = styleSheet.ownerNode
+        let style_id = ''
 
-          if (style_node && 'id' in style_node) {
-            style_id = style_node.id
-          }
-
-          if (style_id) {
-            style.setAttribute('id', style_id)
-          }
-          style.textContent = cssRules
-          pip.document.head.appendChild(style)
-        } catch (e) {
-          const link = document.createElement('link')
-          if (styleSheet.href == null) {
-            return
-          }
-
-          link.rel = 'stylesheet'
-          link.type = styleSheet.type
-          link.media = styleSheet.media.toString()
-          link.href = styleSheet.href
-          pip.document.head.appendChild(link)
+        if (style_node && 'id' in style_node) {
+          style_id = style_node.id
         }
-      })
+
+        if (style_id) {
+          style.setAttribute('id', style_id)
+        }
+        style.textContent = cssRules
+        pip.document.head.appendChild(style)
+      } catch (e) {
+        const link = document.createElement('link')
+        if (styleSheet.href == null) {
+          return
+        }
+
+        link.rel = 'stylesheet'
+        link.type = styleSheet.type
+        link.media = styleSheet.media.toString()
+        link.href = styleSheet.href
+        pip.document.head.appendChild(link)
+      }
+    })
     delegateEvents(
       [
         'focusin',

--- a/packages/devtools/src/context/pip-context.tsx
+++ b/packages/devtools/src/context/pip-context.tsx
@@ -55,7 +55,7 @@ export const PiPProvider = (props: PiPProviderProps) => {
       )
     }
 
-    import.meta?.hot?.on('vite:beforeUpdate', () => {
+    import.meta.hot?.on('vite:beforeUpdate', () => {
       localStorage.setItem('pip_open', 'false')
       closePipWindow()
     })
@@ -77,39 +77,39 @@ export const PiPProvider = (props: PiPProviderProps) => {
       closePipWindow()
     })
 
-    // It is important to copy all parent window styles. Otherwise, there would be no CSS available at all
-    // https://developer.chrome.com/docs/web-platform/document-picture-in-picture/#copy-style-sheets-to-the-picture-in-picture-window
-    ;[...document.styleSheets].forEach((styleSheet) => {
-      try {
-        const cssRules = [...styleSheet.cssRules]
-          .map((rule) => rule.cssText)
-          .join('')
-        const style = document.createElement('style')
-        const style_node = styleSheet.ownerNode
-        let style_id = ''
+      // It is important to copy all parent window styles. Otherwise, there would be no CSS available at all
+      // https://developer.chrome.com/docs/web-platform/document-picture-in-picture/#copy-style-sheets-to-the-picture-in-picture-window
+      ;[...document.styleSheets].forEach((styleSheet) => {
+        try {
+          const cssRules = [...styleSheet.cssRules]
+            .map((rule) => rule.cssText)
+            .join('')
+          const style = document.createElement('style')
+          const style_node = styleSheet.ownerNode
+          let style_id = ''
 
-        if (style_node && 'id' in style_node) {
-          style_id = style_node.id
-        }
+          if (style_node && 'id' in style_node) {
+            style_id = style_node.id
+          }
 
-        if (style_id) {
-          style.setAttribute('id', style_id)
-        }
-        style.textContent = cssRules
-        pip.document.head.appendChild(style)
-      } catch (e) {
-        const link = document.createElement('link')
-        if (styleSheet.href == null) {
-          return
-        }
+          if (style_id) {
+            style.setAttribute('id', style_id)
+          }
+          style.textContent = cssRules
+          pip.document.head.appendChild(style)
+        } catch (e) {
+          const link = document.createElement('link')
+          if (styleSheet.href == null) {
+            return
+          }
 
-        link.rel = 'stylesheet'
-        link.type = styleSheet.type
-        link.media = styleSheet.media.toString()
-        link.href = styleSheet.href
-        pip.document.head.appendChild(link)
-      }
-    })
+          link.rel = 'stylesheet'
+          link.type = styleSheet.type
+          link.media = styleSheet.media.toString()
+          link.href = styleSheet.href
+          pip.document.head.appendChild(link)
+        }
+      })
     delegateEvents(
       [
         'focusin',

--- a/packages/devtools/src/context/pip-context.tsx
+++ b/packages/devtools/src/context/pip-context.tsx
@@ -55,9 +55,7 @@ export const PiPProvider = (props: PiPProviderProps) => {
       )
     }
 
-    const meta = typeof import.meta !== 'undefined' ? import.meta : null
-
-    meta?.hot?.on('vite:beforeUpdate', () => {
+    import.meta?.hot?.on('vite:beforeUpdate', () => {
       localStorage.setItem('pip_open', 'false')
       closePipWindow()
     })


### PR DESCRIPTION
rsbuild requires directly property access otherwise it will throw: Accessing import.meta directly is unsupported (only property access or destructuring is supported)

## 🎯 Changes

Fix usage in rsbuild

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
