### PR TITLE
fix: add css format specifier support to enhancedConsoleLog

### DIFF
--- a/examples/react/start/src/routes/__root.tsx
+++ b/examples/react/start/src/routes/__root.tsx
@@ -33,6 +33,7 @@ export const Route = createRootRoute({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  console.log('Rendering Root Document')
   return (
     <html lang="en">
       <head>

--- a/packages/devtools-vite/src/enhance-logs.test.ts
+++ b/packages/devtools-vite/src/enhance-logs.test.ts
@@ -94,7 +94,6 @@ describe('remove-devtools', () => {
         3000,
       )!.code,
     )
-    console.log('output', output)
     expect(
       output.includes(
         'http://localhost:3000/__tsd/open-source?source=test.jsx',
@@ -123,7 +122,6 @@ describe('remove-devtools', () => {
         `,
         'test.jsx',
         3000,
-        true,
       )!.code,
     )
     expect(output.includes('color:#A0A')).toEqual(true)

--- a/packages/devtools-vite/src/enhance-logs.ts
+++ b/packages/devtools-vite/src/enhance-logs.ts
@@ -8,7 +8,6 @@ const transform = (
   ast: ParseResult<Babel.File>,
   filePath: string,
   port: number,
-  cssFormatting: boolean,
 ) => {
   let didTransform = false
 
@@ -32,48 +31,42 @@ const transform = (
           location.start.column,
         ]
         const finalPath = `${filePath}:${lineNumber}:${column + 1}`
-        const logMessage = `${chalk.magenta('LOG')} ${chalk.blueBright(`${finalPath} - http://localhost:${port}/__tsd/open-source?source=${encodeURIComponent(finalPath)}`)}\n → `
-        // Prefer ANSI escape codes for formatting.
-        if (!cssFormatting) {
-          path.node.arguments.unshift(t.stringLiteral(logMessage))
-        } else {
-          const serverLogMessage = t.arrayExpression([
-            t.stringLiteral(logMessage),
-          ])
-          const browserLogMessage = t.arrayExpression([
-            // LOG with css formatting specifiers: %c
-            t.stringLiteral(
-              `%c${'LOG'}%c %c${`${finalPath} - http://localhost:${port}/__tsd/open-source?source=${encodeURIComponent(finalPath)}`}%c \n → `,
-            ),
-            // magenta
-            t.stringLiteral('color:#A0A'),
-            t.stringLiteral('color:#FFF'),
-            // blueBright
-            t.stringLiteral('color:#55F'),
-            t.stringLiteral('color:#FFF'),
-          ])
+        const logMessage = `${chalk.magenta('LOG')} ${chalk.blueBright(`${finalPath}`)}\n → `
 
-          // globalThis.window == undefined
-          const checkServerCondition = t.binaryExpression(
-            '==',
-            t.memberExpression(
-              t.identifier('globalThis'),
-              t.identifier('window'),
-            ),
-            t.identifier('undefined'),
-          )
+        const serverLogMessage = t.arrayExpression([
+          t.stringLiteral(logMessage),
+        ])
+        const browserLogMessage = t.arrayExpression([
+          // LOG with css formatting specifiers: %c
+          t.stringLiteral(
+            `%c${'LOG'}%c %c${`Go to Source: http://localhost:${port}/__tsd/open-source?source=${encodeURIComponent(finalPath)}`}%c \n → `,
+          ),
+          // magenta
+          t.stringLiteral('color:#A0A'),
+          t.stringLiteral('color:#FFF'),
+          // blueBright
+          t.stringLiteral('color:#55F'),
+          t.stringLiteral('color:#FFF'),
+        ])
 
-          // ...(isServer ? checkServerCondition : browserLogMessage)
-          path.node.arguments.unshift(
-            t.spreadElement(
-              t.conditionalExpression(
-                checkServerCondition,
-                serverLogMessage,
-                browserLogMessage,
-              ),
+        // typeof window === "undefined"
+        const checkServerCondition = t.binaryExpression(
+          '===',
+          t.unaryExpression('typeof', t.identifier('window')),
+          t.stringLiteral('undefined'),
+        )
+
+        // ...(isServer ? serverLogMessage : browserLogMessage)
+        path.node.arguments.unshift(
+          t.spreadElement(
+            t.conditionalExpression(
+              checkServerCondition,
+              serverLogMessage,
+              browserLogMessage,
             ),
-          )
-        }
+          ),
+        )
+
         didTransform = true
       }
     },
@@ -82,12 +75,7 @@ const transform = (
   return didTransform
 }
 
-export function enhanceConsoleLog(
-  code: string,
-  id: string,
-  port: number,
-  cssFormatting?: boolean,
-) {
+export function enhanceConsoleLog(code: string, id: string, port: number) {
   const [filePath] = id.split('?')
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const location = filePath?.replace(normalizePath(process.cwd()), '')!
@@ -97,7 +85,7 @@ export function enhanceConsoleLog(
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
     })
-    const didTransform = transform(ast, location, port, cssFormatting === true)
+    const didTransform = transform(ast, location, port)
     if (!didTransform) {
       return
     }

--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -41,12 +41,6 @@ export type TanStackDevtoolsViteConfig = {
      * @default true
      */
     enabled: boolean
-    /**
-     * Whether to use CSS formatting for enhanced logging.
-     * @note Chrome supports ANSI escape codes for formatting. Firefox does not.
-     * @default false
-     */
-    cssFormatting?: boolean
   }
   /**
    * Whether to remove devtools from the production build.
@@ -439,12 +433,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
         )
           return
 
-        return enhanceConsoleLog(
-          code,
-          id,
-          port,
-          enhancedLogsConfig.cssFormatting,
-        )
+        return enhanceConsoleLog(code, id, port)
       },
     },
     {


### PR DESCRIPTION
## 🎯 Changes

Fixes #271
This PR fixes issue #271 for enhanced logs 

- I updated `enhancedConsoleLog` function to allow formatting with CSS Format Specifiers instead of ANSI escape codes
- The `enhancedConsoleLog` takes in an optional 4th param to enable css formatting otherwise it'll fallback to current behavior (ANSI)
- Added option for css formatting in `TanStackDevtoolsViteConfig` type with default value: `false`
- Added a test for css formatting in  `enhance-logs.test.ts` file

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

