### PR TITLE
fix: change source inspector hotkey to avoid macOS screenshot conflict

### DIFF
--- a/packages/devtools/src/context/devtools-store.ts
+++ b/packages/devtools/src/context/devtools-store.ts
@@ -54,7 +54,7 @@ export type DevtoolsStore = {
     openHotkey: Array<KeyboardKey>
     /**
      * The hotkey to open the source inspector
-     * @default ["Shift", "CtrlOrMeta"]
+     * @default ["Alt", "CtrlOrMeta"]
      */
     inspectHotkey: Array<KeyboardKey>
     /**
@@ -100,7 +100,7 @@ export const initialState: DevtoolsStore = {
     position: 'bottom-right',
     panelLocation: 'bottom',
     openHotkey: ['Control', '~'],
-    inspectHotkey: ['Shift', 'CtrlOrMeta'],
+    inspectHotkey: ['Alt', 'CtrlOrMeta'],
     requireUrlFlag: false,
     urlFlag: 'tanstack-devtools',
     theme:


### PR DESCRIPTION
## Summary
- Changed default source inspector hotkey from `Shift + Cmd/Ctrl` to `Alt + Cmd/Ctrl`
- The previous hotkey clashes with macOS screenshot shortcut (`Cmd + Shift + 4`)