### PR TITLE
feat: add Angular devtools adapter

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -45,6 +45,13 @@
             { "label": "Basic Setup", "to": "framework/vue/basic-setup" },
             { "label": "Vue Adapter", "to": "framework/vue/adapter" }
           ]
+        },
+        {
+          "label": "angular",
+          "children": [
+            { "label": "Basic Setup", "to": "framework/angular/basic-setup" },
+            { "label": "Angular Adapter", "to": "framework/angular/adapter" }
+          ]
         }
       ]
     },
@@ -89,6 +96,12 @@
           "children": [
             { "label": "Custom Plugins", "to": "framework/vue/guides/custom-plugins" }
           ]
+        },
+        {
+          "label": "angular",
+          "children": [
+            { "label": "Custom Plugins", "to": "framework/angular/guides/custom-plugins" }
+          ]
         }
       ]
     },
@@ -120,6 +133,12 @@
           "label": "vue",
           "children": [
             { "label": "Vue Reference", "to": "framework/vue/reference/index" }
+          ]
+        },
+        {
+          "label": "angular",
+          "children": [
+            { "label": "Angular Reference", "to": "framework/angular/reference/index" }
           ]
         }
       ]

--- a/docs/devtools-utils.md
+++ b/docs/devtools-utils.md
@@ -37,6 +37,9 @@ import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/preact'
 
 // Vue
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/vue'
+
+// Angular
+import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/angular'
 ```
 
 ## React
@@ -251,6 +254,49 @@ const [MyPanel, NoOpPanel] = createVuePanel(MyDevtoolsCore)
 ```
 
 The panel component accepts `theme` and `devtoolsProps` as props. It mounts the core instance into a `div` element on `onMounted` and calls `unmount()` on `onUnmounted`.
+
+## Angular
+
+### createAngularPlugin
+
+The Angular factory takes a `name` string and an Angular component class as separate arguments, similar to the Vue API.
+
+**Signature:**
+
+```ts
+function createAngularPlugin(
+  name: string,
+  component: Type<any>,
+): readonly [Plugin, NoOpPlugin]
+```
+
+**Usage:**
+
+```ts
+import { createAngularPlugin } from '@tanstack/devtools-utils/angular'
+import { MyStorePanelComponent } from './my-store-panel.component'
+
+const [MyPlugin, NoOpPlugin] = createAngularPlugin('My Store', MyStorePanelComponent)
+```
+
+The returned functions:
+
+- **`Plugin(inputs?)`** -- returns `{ name, component, inputs }` where `component` is your Angular component class.
+- **`NoOpPlugin(inputs?)`** -- returns `{ name, component: NoOpComponent, inputs }` where the component is an empty standalone component (renders nothing visible).
+
+Both accept an optional `inputs` object that gets forwarded to the component via `setInput()`.
+
+### createAngularPanel
+
+For class-based devtools cores, Angular provides `createAngularPanel`. It creates a standalone Angular component that handles mounting and unmounting the core class:
+
+```ts
+import { createAngularPanel } from '@tanstack/devtools-utils/angular'
+
+const [MyPanel, NoOpPanel] = createAngularPanel(MyDevtoolsCore)
+```
+
+The panel component accepts `theme` and `devtoolsProps` as signal inputs. It mounts the core instance into a `div` element using `afterNextRender` and calls `unmount()` via `DestroyRef.onDestroy`.
 
 ## When to Use Factories vs Manual Plugin Objects
 

--- a/docs/framework/angular/adapter.md
+++ b/docs/framework/angular/adapter.md
@@ -1,0 +1,82 @@
+---
+title: TanStack Devtools Angular Adapter
+id: adapter
+---
+
+The Angular adapter wraps `TanStackDevtoolsCore` in an Angular standalone component, using Angular's `createComponent` and `ApplicationRef.attachView` to dynamically render plugins into the correct DOM containers managed by the devtools shell.
+
+## Installation
+
+```sh
+npm install @tanstack/angular-devtools
+```
+
+## Component Inputs
+
+The `TanStackDevtoolsComponent` (selector: `tanstack-devtools`) accepts the following signal-based inputs, defined by the `TanStackDevtoolsAngularInit` interface:
+
+| Input | Type | Description |
+| --- | --- | --- |
+| `plugins` | `TanStackDevtoolsAngularPlugin[]` | Array of plugins to render inside the devtools panel. |
+| `config` | `Partial<TanStackDevtoolsConfig>` | Configuration for the devtools shell. Sets the initial state on first load; afterwards settings are persisted in local storage. |
+| `eventBusConfig` | `ClientEventBusConfig` | Configuration for the TanStack Devtools client event bus. |
+
+## Plugin Type
+
+Each plugin in the `plugins` array must conform to the `TanStackDevtoolsAngularPlugin` type:
+
+```ts
+type TanStackDevtoolsAngularPlugin = {
+  id?: string
+  component: Type<any>
+  name: string | Type<any>
+  inputs?: Record<string, any>
+  defaultOpen?: boolean
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` (optional) | Unique identifier for the plugin. |
+| `component` | `Type<any>` | The Angular component class to render as the plugin panel content. |
+| `name` | `string \| Type<any>` | Display name for the tab title. Can be a plain string or an Angular component class for custom rendering. |
+| `inputs` | `Record<string, any>` (optional) | Additional inputs passed to the plugin component via `setInput()`. |
+| `defaultOpen` | `boolean` (optional) | Whether this plugin tab should be open by default. |
+
+## Key Differences from Other Frameworks
+
+The Angular adapter uses `component` (an Angular component class reference) instead of `render` (a JSX element) in plugin definitions. Inputs are provided through the `inputs` field and bound to the component with `setInput()`, rather than being embedded directly in a JSX expression or passed via `v-bind`.
+
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+import { AngularQueryDevtoolsPanel } from '@tanstack/angular-query-devtools'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <tanstack-devtools [plugins]="plugins" />
+  `,
+})
+export class AppComponent {
+  plugins = [
+    {
+      name: 'Angular Query',
+      component: AngularQueryDevtoolsPanel,
+      inputs: { style: 'height: 100%' },
+    },
+  ]
+}
+```
+
+## Exports
+
+The `@tanstack/angular-devtools` package exports:
+
+- **`TanStackDevtoolsComponent`** -- The main Angular standalone component that renders the devtools panel.
+- **`TanStackDevtoolsAngularPlugin`** (type) -- The type for plugin definitions.
+- **`TanStackDevtoolsAngularInit`** (type) -- The inputs interface for the `TanStackDevtoolsComponent`.
+
+The package depends on `@tanstack/devtools` (the core package), which provides `TanStackDevtoolsCore`, `TanStackDevtoolsConfig`, `ClientEventBusConfig`, and other core utilities.

--- a/docs/framework/angular/basic-setup.md
+++ b/docs/framework/angular/basic-setup.md
@@ -1,0 +1,63 @@
+---
+title: Basic setup
+id: basic-setup
+---
+
+TanStack Devtools provides you with an easy-to-use and modular client that allows you to compose multiple devtools into one easy-to-use panel.
+
+## Setup
+
+Install the [TanStack Devtools](https://www.npmjs.com/package/@tanstack/angular-devtools) library. This will install the devtools core as well as provide you with the Angular-specific adapter.
+
+```bash
+npm i @tanstack/angular-devtools
+```
+
+Next, in the root of your application, import the `TanStackDevtoolsComponent` from `@tanstack/angular-devtools` and add it to your template.
+
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <app-content />
+    <tanstack-devtools />
+  `,
+})
+export class AppComponent {}
+```
+
+Import the desired devtools and provide them to the `TanStackDevtoolsComponent` via the `[plugins]` input along with a label for the menu.
+
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+import type { TanStackDevtoolsAngularPlugin } from '@tanstack/angular-devtools'
+import { AngularQueryDevtoolsPanel } from '@tanstack/angular-query-devtools'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <app-content />
+    <tanstack-devtools [plugins]="plugins" />
+  `,
+})
+export class AppComponent {
+  plugins: Array<TanStackDevtoolsAngularPlugin> = [
+    {
+      name: 'Angular Query',
+      component: AngularQueryDevtoolsPanel,
+    },
+  ]
+}
+```
+
+> Note: The Angular adapter uses `component` (an Angular component class) instead of `render` (a JSX element) in plugin definitions. Additional inputs can be provided via the `inputs` field and are bound to the component with `setInput()`.
+
+Finally, add any additional configuration you desire to the `TanStackDevtoolsComponent`. More information can be found under the [TanStack Devtools Configuration](../../configuration) section.

--- a/docs/framework/angular/guides/custom-plugins.md
+++ b/docs/framework/angular/guides/custom-plugins.md
@@ -1,0 +1,217 @@
+---
+title: Custom plugins
+id: custom-plugins
+---
+
+TanStack devtools allows you to create your own custom plugins by emitting and listening to our event bus.
+
+## Prerequisite
+
+This guide will walk you through a simple example where our library is a counter with a count history. A working example can be found in our [custom-plugin example](https://tanstack.com/devtools/latest/docs/framework/react/examples/custom-devtools).
+
+This is our library code:
+
+counter.ts
+```tsx
+export function createCounter() {
+  let count = 0
+  const history = []
+
+  return {
+    getCount: () => count,
+    increment: () => {
+      count++
+      history.push(count)
+    },
+    decrement: () => {
+      count--
+      history.push(count)
+    },
+  };
+}
+```
+
+## Event Client Setup
+
+Install the [TanStack Devtools Event Client](https://www.npmjs.com/package/@tanstack/devtools-event-client) utils.
+
+```bash
+npm i @tanstack/devtools-event-client
+```
+
+First you will need to setup the `EventClient`.
+
+eventClient.ts
+```tsx
+import { EventClient } from '@tanstack/devtools-event-client'
+
+
+type EventMap = {
+  // The key is the event suffix only — the pluginId is prepended automatically by EventClient
+  // The value is the expected type of the event payload
+  'counter-state': { count: number, history: number[] }
+}
+
+class CustomEventClient extends EventClient<EventMap> {
+  constructor() {
+    super({
+      // The pluginId is prepended to event map keys when emitting/listening
+      pluginId: 'custom-devtools',
+    })
+  }
+}
+
+// This is where the magic happens, it'll be used throughout your application.
+export const DevtoolsEventClient = new CustomEventClient()
+```
+
+## Event Client Integration
+
+Now we need to hook our `EventClient` into the application code. This can be done in many way's, a useEffect that emits the current state, or a subscription to an observer, all that matters is that when you want to emit the current state you do the following.
+
+Our new library code will looks as follows:
+
+counter.ts
+```tsx
+import { DevtoolsEventClient } from './eventClient.ts'
+
+export function createCounter() {
+  let count = 0
+  const history: Array<number> = []
+
+  return {
+    getCount: () => count,
+    increment: () => {
+      count++
+      history.push(count)
+
+      // The emit eventSuffix must match that of the EventMap defined in eventClient.ts
+      DevtoolsEventClient.emit('counter-state', {
+        count,
+        history,
+      })
+    },
+    decrement: () => {
+      count--
+      history.push(count)
+
+      DevtoolsEventClient.emit('counter-state', {
+        count,
+        history,
+      })
+    },
+  }
+}
+```
+
+> [!IMPORTANT]
+> `EventClient` is framework agnostic so this process will be the same regardless of framework or even in vanilla JavaScript.
+
+## Consuming The Event Client
+
+Now we need to create our devtools panel. For Angular, create a standalone component that listens to events from the `EventClient`.
+
+DevtoolPanel.ts
+```typescript
+import { Component, OnDestroy, OnInit, signal } from '@angular/core'
+import { DevtoolsEventClient } from './eventClient'
+
+@Component({
+  selector: 'devtool-panel',
+  standalone: true,
+  template: `
+    <div>
+      <div>{{ state()?.count }}</div>
+      <div>{{ stateHistory() }}</div>
+    </div>
+  `,
+})
+export class DevtoolPanelComponent implements OnInit, OnDestroy {
+  state = signal<{ count: number; history: number[] } | undefined>(undefined)
+  private cleanup?: () => void
+
+  get stateHistory() {
+    return JSON.stringify(this.state()?.history)
+  }
+
+  ngOnInit() {
+    this.cleanup = DevtoolsEventClient.on('counter-state', (e) => {
+      this.state.set(e.payload)
+    })
+  }
+
+  ngOnDestroy() {
+    this.cleanup?.()
+  }
+}
+```
+
+## Application Integration
+
+This step follows what's shown in [basic-setup](../basic-setup) for a more documented guide go check it out.
+
+app.component.ts
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+import type { TanStackDevtoolsAngularPlugin } from '@tanstack/angular-devtools'
+import { DevtoolPanelComponent } from './devtool-panel.component'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <app-content />
+    <tanstack-devtools [plugins]="plugins" />
+  `,
+})
+export class AppComponent {
+  plugins: Array<TanStackDevtoolsAngularPlugin> = [
+    { name: 'Custom devtools', component: DevtoolPanelComponent },
+  ]
+}
+```
+
+## Debugging
+
+Both the `TanStackDevtoolsComponent` and the TanStack `EventClient` come with built in debug mode which will log to the console the emitted event as well as the EventClient status.
+
+TanStackDevtools debugging mode can be activated like so:
+```typescript
+@Component({
+  template: `
+    <tanstack-devtools
+      [eventBusConfig]="{ debug: true }"
+      [plugins]="plugins"
+    />
+  `,
+  imports: [TanStackDevtoolsComponent],
+})
+export class AppComponent {
+  plugins: Array<TanStackDevtoolsAngularPlugin> = [
+    { name: 'Custom devtools', component: DevtoolPanelComponent },
+  ]
+}
+```
+
+Where as the EventClient's debug mode can be activated by:
+```tsx
+class CustomEventClient extends EventClient<EventMap> {
+  constructor() {
+    super({
+      pluginId: 'custom-devtools',
+      debug: true,
+    })
+  }
+}
+```
+
+Activating the debug mode will log to the console the current events that emitter has emitted or listened to. The EventClient will have appended `[tanstack-devtools:${pluginId}]` and the client will have appended `[tanstack-devtools:client-bus]`.
+
+Heres an example of both:
+```
+[tanstack-devtools:client-bus] Initializing client event bus
+
+[tanstack-devtools:custom-devtools-plugin] Registered event to bus custom-devtools:counter-state
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,20 @@ npm install -D @tanstack/devtools-vite
 
 TanStack Devtools is compatible with Vue 3+
 
+## Angular
+
+```sh
+npm install -D @tanstack/angular-devtools
+```
+
+The Vite plugin (`@tanstack/devtools-vite`) is optional for Angular — it enables additional features like source inspection and console piping but isn't required for basic usage.
+
+```sh
+npm install -D @tanstack/devtools-vite
+```
+
+TanStack Devtools is compatible with Angular 19+
+
 ## Vanilla JS
 
 ```sh

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@ title: Quick Start
 id: quick-start
 ---
 
-TanStack Devtools is a framework-agnostic devtool for managing and debugging devtools plugins across React, Preact, Solid, and Vue. Pick your framework below to get started.
+TanStack Devtools is a framework-agnostic devtool for managing and debugging devtools plugins across React, Preact, Solid, Vue, and Angular. Pick your framework below to get started.
 
 ## React
 
@@ -202,6 +202,56 @@ const plugins: TanStackDevtoolsVuePlugin[] = [
   <App />
   <TanStackDevtools :plugins="plugins" />
 </template>
+```
+
+## Angular
+
+Install the devtools:
+
+```bash
+npm install @tanstack/angular-devtools
+```
+
+Add the `TanStackDevtoolsComponent` to the root of your application:
+
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <app-content />
+    <tanstack-devtools />
+  `,
+})
+export class AppComponent {}
+```
+
+To add plugins, define them as an array and pass them via the `[plugins]` input. Angular uses `component` instead of `render` in plugin definitions:
+
+```typescript
+import { Component } from '@angular/core'
+import { TanStackDevtoolsComponent } from '@tanstack/angular-devtools'
+import type { TanStackDevtoolsAngularPlugin } from '@tanstack/angular-devtools'
+import { AngularQueryDevtoolsPanel } from '@tanstack/angular-query-devtools'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackDevtoolsComponent],
+  template: `
+    <app-content />
+    <tanstack-devtools [plugins]="plugins" />
+  `,
+})
+export class AppComponent {
+  plugins: Array<TanStackDevtoolsAngularPlugin> = [
+    { name: 'Angular Query', component: AngularQueryDevtoolsPanel },
+  ]
+}
 ```
 
 ## Vite Plugin

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@tanstack/react-devtools": "workspace:*",
     "@tanstack/preact-devtools": "workspace:*",
     "@tanstack/solid-devtools": "workspace:*",
-    "@tanstack/devtools-vite": "workspace:*"
+    "@tanstack/devtools-vite": "workspace:*",
+    "@tanstack/angular-devtools": "workspace:*"
   }
 }

--- a/packages/angular-devtools/eslint.config.js
+++ b/packages/angular-devtools/eslint.config.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+import rootConfig from '../../eslint.config.js'
+
+export default [
+  ...rootConfig,
+]

--- a/packages/angular-devtools/eslint.config.js
+++ b/packages/angular-devtools/eslint.config.js
@@ -2,6 +2,4 @@
 
 import rootConfig from '../../eslint.config.js'
 
-export default [
-  ...rootConfig,
-]
+export default [...rootConfig]

--- a/packages/angular-devtools/package.json
+++ b/packages/angular-devtools/package.json
@@ -52,11 +52,7 @@
   },
   "devDependencies": {
     "@angular/compiler": "^20.0.0",
-    "@angular/compiler-cli": "^20.0.0",
-    "@angular/core": "^20.0.0",
-    "@angular/platform-browser": "^20.0.0",
-    "@angular/platform-browser-dynamic": "^20.0.0",
-    "zone.js": "^0.15.0"
+    "@angular/core": "^20.0.0"
   },
   "peerDependencies": {
     "@angular/core": ">=19.0.0",

--- a/packages/angular-devtools/package.json
+++ b/packages/angular-devtools/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@tanstack/angular-devtools",
+  "version": "0.0.1",
+  "description": "TanStack Devtools is a set of tools for building advanced devtools for your Angular application.",
+  "author": "Tanner Linsley",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/devtools.git",
+    "directory": "packages/angular-devtools"
+  },
+  "homepage": "https://tanstack.com/devtools",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "keywords": [
+    "angular",
+    "devtools"
+  ],
+  "type": "module",
+  "types": "dist/esm/index.d.ts",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "clean": "premove ./build ./dist",
+    "test:eslint": "eslint ./src",
+    "test:lib": "vitest --passWithNoTests",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc",
+    "test:build": "publint --strict",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@tanstack/devtools": "workspace:*"
+  },
+  "devDependencies": {
+    "@analogjs/vite-plugin-angular": "^1.15.0",
+    "@angular/compiler": "^19.0.0",
+    "@angular/compiler-cli": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/platform-browser": "^19.0.0",
+    "@angular/platform-browser-dynamic": "^19.0.0",
+    "zone.js": "^0.15.0"
+  },
+  "peerDependencies": {
+    "@angular/core": ">=19.0.0",
+    "@angular/platform-browser": ">=19.0.0"
+  }
+}

--- a/packages/angular-devtools/package.json
+++ b/packages/angular-devtools/package.json
@@ -51,12 +51,11 @@
     "@tanstack/devtools": "workspace:*"
   },
   "devDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.15.0",
-    "@angular/compiler": "^19.0.0",
-    "@angular/compiler-cli": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "@angular/platform-browser": "^19.0.0",
-    "@angular/platform-browser-dynamic": "^19.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
     "zone.js": "^0.15.0"
   },
   "peerDependencies": {

--- a/packages/angular-devtools/src/devtools.ts
+++ b/packages/angular-devtools/src/devtools.ts
@@ -10,10 +10,7 @@ import {
   inject,
   input,
 } from '@angular/core'
-import {
-  PLUGIN_CONTAINER_ID,
-  TanStackDevtoolsCore,
-} from '@tanstack/devtools'
+import { PLUGIN_CONTAINER_ID, TanStackDevtoolsCore } from '@tanstack/devtools'
 import type { ComponentRef, Type } from '@angular/core'
 import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
 import type {
@@ -85,7 +82,9 @@ export class TanStackDevtoolsComponent {
     return plugins.map((plugin) => this.convertPlugin(plugin))
   }
 
-  private convertPlugin(plugin: TanStackDevtoolsAngularPlugin): TanStackDevtoolsPlugin {
+  private convertPlugin(
+    plugin: TanStackDevtoolsAngularPlugin,
+  ): TanStackDevtoolsPlugin {
     return {
       id: plugin.id,
       defaultOpen: plugin.defaultOpen,
@@ -105,9 +104,7 @@ export class TanStackDevtoolsComponent {
         })
       },
       destroy: (pluginId) => {
-        this.destroyComponentsInContainer(
-          `${PLUGIN_CONTAINER_ID}-${pluginId}`,
-        )
+        this.destroyComponentsInContainer(`${PLUGIN_CONTAINER_ID}-${pluginId}`)
       },
     }
   }

--- a/packages/angular-devtools/src/devtools.ts
+++ b/packages/angular-devtools/src/devtools.ts
@@ -6,6 +6,7 @@ import {
   EnvironmentInjector,
   afterNextRender,
   createComponent,
+  effect,
   inject,
   input,
 } from '@angular/core'
@@ -52,6 +53,20 @@ export class TanStackDevtoolsComponent {
       })
 
       this.devtools.mount(hostEl)
+    })
+
+    effect(() => {
+      const plugins = this.plugins()
+      const config = this.config()
+      const eventBusConfig = this.eventBusConfig()
+
+      if (this.devtools) {
+        this.devtools.setConfig({
+          config,
+          eventBusConfig,
+          plugins: plugins?.map((p) => this.convertPlugin(p)) ?? [],
+        })
+      }
     })
 
     this.destroyRef.onDestroy(() => {

--- a/packages/angular-devtools/src/devtools.ts
+++ b/packages/angular-devtools/src/devtools.ts
@@ -33,7 +33,7 @@ export class TanStackDevtoolsComponent {
   private injector = inject(EnvironmentInjector)
   private destroyRef = inject(DestroyRef)
 
-  private componentRefs: ComponentRef<any>[] = []
+  private componentRefs: Array<ComponentRef<any>> = []
   private devtools: TanStackDevtoolsCore | null = null
 
   constructor() {

--- a/packages/angular-devtools/src/devtools.ts
+++ b/packages/angular-devtools/src/devtools.ts
@@ -1,0 +1,138 @@
+import {
+  ApplicationRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  EnvironmentInjector,
+  afterNextRender,
+  createComponent,
+  inject,
+  input,
+} from '@angular/core'
+import {
+  PLUGIN_CONTAINER_ID,
+  TanStackDevtoolsCore,
+} from '@tanstack/devtools'
+import type { ComponentRef, Type } from '@angular/core'
+import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
+import type {
+  TanStackDevtoolsAngularInit,
+  TanStackDevtoolsAngularPlugin,
+} from './types'
+
+@Component({
+  selector: 'tanstack-devtools',
+  standalone: true,
+  template: '<div #devtoolsHost></div>',
+})
+export class TanStackDevtoolsComponent {
+  plugins = input<TanStackDevtoolsAngularInit['plugins']>()
+  config = input<TanStackDevtoolsAngularInit['config']>()
+  eventBusConfig = input<TanStackDevtoolsAngularInit['eventBusConfig']>()
+
+  private hostRef = inject(ElementRef)
+  private appRef = inject(ApplicationRef)
+  private injector = inject(EnvironmentInjector)
+  private destroyRef = inject(DestroyRef)
+
+  private componentRefs: ComponentRef<any>[] = []
+  private devtools: TanStackDevtoolsCore | null = null
+
+  constructor() {
+    afterNextRender(() => {
+      const hostEl = this.hostRef.nativeElement.querySelector('div')
+      if (!hostEl) return
+
+      const pluginsMap = this.getPluginsMap()
+
+      this.devtools = new TanStackDevtoolsCore({
+        config: this.config(),
+        eventBusConfig: this.eventBusConfig(),
+        plugins: pluginsMap,
+      })
+
+      this.devtools.mount(hostEl)
+    })
+
+    this.destroyRef.onDestroy(() => {
+      this.destroyAllComponents()
+      if (this.devtools) {
+        this.devtools.unmount()
+        this.devtools = null
+      }
+    })
+  }
+
+  private getPluginsMap(): Array<TanStackDevtoolsPlugin> {
+    const plugins = this.plugins()
+    if (!plugins) return []
+
+    return plugins.map((plugin) => this.convertPlugin(plugin))
+  }
+
+  private convertPlugin(plugin: TanStackDevtoolsAngularPlugin): TanStackDevtoolsPlugin {
+    return {
+      id: plugin.id,
+      defaultOpen: plugin.defaultOpen,
+      name:
+        typeof plugin.name === 'string'
+          ? plugin.name
+          : (e, theme) => {
+              this.renderComponent(plugin.name as Type<any>, e, {
+                theme,
+                ...(plugin.inputs ?? {}),
+              })
+            },
+      render: (e, theme) => {
+        this.renderComponent(plugin.component, e, {
+          theme,
+          ...(plugin.inputs ?? {}),
+        })
+      },
+      destroy: (pluginId) => {
+        this.destroyComponentsInContainer(
+          `${PLUGIN_CONTAINER_ID}-${pluginId}`,
+        )
+      },
+    }
+  }
+
+  private renderComponent(
+    component: Type<any>,
+    container: HTMLElement,
+    inputs: Record<string, unknown>,
+  ) {
+    const componentRef = createComponent(component, {
+      environmentInjector: this.injector,
+      hostElement: container,
+    })
+
+    for (const [key, value] of Object.entries(inputs)) {
+      componentRef.setInput(key, value)
+    }
+
+    this.appRef.attachView(componentRef.hostView)
+    componentRef.changeDetectorRef.detectChanges()
+    this.componentRefs.push(componentRef)
+  }
+
+  private destroyComponentsInContainer(containerId: string) {
+    this.componentRefs = this.componentRefs.filter((ref) => {
+      const el = ref.location.nativeElement as HTMLElement
+      if (el.parentElement?.id === containerId) {
+        this.appRef.detachView(ref.hostView)
+        ref.destroy()
+        return false
+      }
+      return true
+    })
+  }
+
+  private destroyAllComponents() {
+    for (const ref of this.componentRefs) {
+      this.appRef.detachView(ref.hostView)
+      ref.destroy()
+    }
+    this.componentRefs = []
+  }
+}

--- a/packages/angular-devtools/src/index.ts
+++ b/packages/angular-devtools/src/index.ts
@@ -1,0 +1,6 @@
+export { TanStackDevtoolsComponent } from './devtools'
+
+export type {
+  TanStackDevtoolsAngularPlugin,
+  TanStackDevtoolsAngularInit,
+} from './types'

--- a/packages/angular-devtools/src/types.ts
+++ b/packages/angular-devtools/src/types.ts
@@ -42,9 +42,3 @@ export interface TanStackDevtoolsAngularInit {
    */
   eventBusConfig?: ClientEventBusConfig
 }
-
-export type RenderArray = Array<{
-  id: string
-  component: Type<any>
-  inputs: Record<string, unknown>
-}>

--- a/packages/angular-devtools/src/types.ts
+++ b/packages/angular-devtools/src/types.ts
@@ -1,0 +1,50 @@
+import type { Type } from '@angular/core'
+import type {
+  ClientEventBusConfig,
+  TanStackDevtoolsConfig,
+} from '@tanstack/devtools'
+
+export type TanStackDevtoolsAngularPlugin = {
+  id?: string
+  component: Type<any>
+  name: string | Type<any>
+  inputs?: Record<string, any>
+  defaultOpen?: boolean
+}
+
+export interface TanStackDevtoolsAngularInit {
+  /**
+   * Array of plugins to be used in the devtools.
+   * Each plugin should have a `component` that is an Angular component class.
+   *
+   * Example:
+   * ```typescript
+   * @Component({
+   *   template: `<tanstack-devtools [plugins]="plugins" />`,
+   *   imports: [TanStackDevtoolsComponent],
+   * })
+   * class AppComponent {
+   *   plugins: TanStackDevtoolsAngularPlugin[] = [
+   *     { name: 'My Plugin', component: MyPluginComponent }
+   *   ];
+   * }
+   * ```
+   */
+  plugins?: Array<TanStackDevtoolsAngularPlugin>
+  /**
+   * Configuration for the devtools shell. These configuration options are used to set the
+   * initial state of the devtools when it is started for the first time. Afterwards,
+   * the settings are persisted in local storage and changed through the settings panel.
+   */
+  config?: Partial<TanStackDevtoolsConfig>
+  /**
+   * Configuration for the TanStack Devtools client event bus.
+   */
+  eventBusConfig?: ClientEventBusConfig
+}
+
+export type RenderArray = Array<{
+  id: string
+  component: Type<any>
+  inputs: Record<string, unknown>
+}>

--- a/packages/angular-devtools/tsconfig.json
+++ b/packages/angular-devtools/tsconfig.json
@@ -3,12 +3,5 @@
   "compilerOptions": {
     "experimentalDecorators": true
   },
-  "include": ["src", "eslint.config.js", "vite.config.ts", "tests"],
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-    "compilationMode": "partial"
-  }
+  "include": ["src", "eslint.config.js", "vite.config.ts", "tests"]
 }

--- a/packages/angular-devtools/tsconfig.json
+++ b/packages/angular-devtools/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  },
+  "include": ["src", "eslint.config.js", "vite.config.ts", "tests"],
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true,
+    "compilationMode": "partial"
+  }
+}

--- a/packages/angular-devtools/vite.config.ts
+++ b/packages/angular-devtools/vite.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
-import angular from '@analogjs/vite-plugin-angular'
 import packageJson from './package.json'
 
 const config = defineConfig({
-  plugins: [angular() as any],
+  plugins: [],
   test: {
     name: packageJson.name,
     dir: './tests',

--- a/packages/angular-devtools/vite.config.ts
+++ b/packages/angular-devtools/vite.config.ts
@@ -18,7 +18,12 @@ export default mergeConfig(
   tanstackViteConfig({
     entry: ['./src/index.ts'],
     srcDir: './src',
-    externalDeps: ['@angular/core', '@angular/platform-browser', 'rxjs', 'zone.js'],
+    externalDeps: [
+      '@angular/core',
+      '@angular/platform-browser',
+      'rxjs',
+      'zone.js',
+    ],
     cjs: false,
   }),
 )

--- a/packages/angular-devtools/vite.config.ts
+++ b/packages/angular-devtools/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import angular from '@analogjs/vite-plugin-angular'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  plugins: [angular() as any],
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    globals: true,
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.ts'],
+    srcDir: './src',
+    externalDeps: ['@angular/core', '@angular/platform-browser', 'rxjs', 'zone.js'],
+    cjs: false,
+  }),
+)

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -69,14 +69,17 @@
     "@tanstack/devtools-ui": "workspace:^"
   },
   "peerDependencies": {
+    "@angular/core": ">=19.0.0",
     "@types/react": ">=17.0.0",
     "preact": ">=10.0.0",
     "react": ">=17.0.0",
     "solid-js": ">=1.9.7",
-    "vue": ">=3.2.0",
-    "@angular/core": ">=19.0.0"
+    "vue": ">=3.2.0"
   },
   "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     },
@@ -90,9 +93,6 @@
       "optional": true
     },
     "vue": {
-      "optional": true
-    },
-    "@angular/core": {
       "optional": true
     }
   },
@@ -111,10 +111,6 @@
     "build": "vite build && vite build --config vite.config.preact.ts && vite build --config vite.config.vue.ts && vite build --config vite.config.angular.ts && tsup "
   },
   "devDependencies": {
-    "@angular/compiler": "^20.0.0",
-    "@angular/compiler-cli": "^20.0.0",
-    "@angular/core": "^20.0.0",
-    "@angular/platform-browser": "^20.0.0",
     "tsup": "^8.5.0",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.11.8"

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -53,6 +53,12 @@
         "default": "./dist/vue/esm/index.js"
       }
     },
+    "./angular": {
+      "import": {
+        "types": "./dist/angular/esm/index.d.ts",
+        "default": "./dist/angular/esm/index.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -67,7 +73,8 @@
     "preact": ">=10.0.0",
     "react": ">=17.0.0",
     "solid-js": ">=1.9.7",
-    "vue": ">=3.2.0"
+    "vue": ">=3.2.0",
+    "@angular/core": ">=19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -84,6 +91,9 @@
     },
     "vue": {
       "optional": true
+    },
+    "@angular/core": {
+      "optional": true
     }
   },
   "files": [
@@ -98,9 +108,14 @@
     "test:lib:dev": "pnpm test:lib --watch",
     "test:types": "tsc",
     "test:build": "publint --strict",
-    "build": "vite build && vite build --config vite.config.preact.ts && vite build --config vite.config.vue.ts && tsup "
+    "build": "vite build && vite build --config vite.config.preact.ts && vite build --config vite.config.vue.ts && vite build --config vite.config.angular.ts && tsup "
   },
   "devDependencies": {
+    "@analogjs/vite-plugin-angular": "^1.15.0",
+    "@angular/compiler": "^19.0.0",
+    "@angular/compiler-cli": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/platform-browser": "^19.0.0",
     "tsup": "^8.5.0",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.11.8"

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -111,11 +111,10 @@
     "build": "vite build && vite build --config vite.config.preact.ts && vite build --config vite.config.vue.ts && vite build --config vite.config.angular.ts && tsup "
   },
   "devDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.15.0",
-    "@angular/compiler": "^19.0.0",
-    "@angular/compiler-cli": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "@angular/platform-browser": "^19.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
     "tsup": "^8.5.0",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.11.8"

--- a/packages/devtools-utils/src/angular/index.ts
+++ b/packages/devtools-utils/src/angular/index.ts
@@ -1,0 +1,2 @@
+export * from './panel'
+export * from './plugin'

--- a/packages/devtools-utils/src/angular/panel.ts
+++ b/packages/devtools-utils/src/angular/panel.ts
@@ -18,7 +18,9 @@ export function createAngularPanel<
     mount: (el: HTMLElement, theme?: DevtoolsPanelProps['theme']) => void
     unmount: () => void
   },
->(CoreClass: new (props: TComponentProps) => TCoreDevtoolsClass): [Type<any>, Type<any>] {
+>(
+  CoreClass: new (props: TComponentProps) => TCoreDevtoolsClass,
+): [Type<any>, Type<any>] {
   @Component({
     selector: 'devtools-panel',
     standalone: true,
@@ -37,9 +39,7 @@ export function createAngularPanel<
         const el = this.hostRef.nativeElement.querySelector('div')
         if (!el) return
 
-        const instance = new CoreClass(
-          this.devtoolsProps() as TComponentProps,
-        )
+        const instance = new CoreClass(this.devtoolsProps() as TComponentProps)
         this.devtools = instance
         instance.mount(el, this.theme())
       })

--- a/packages/devtools-utils/src/angular/panel.ts
+++ b/packages/devtools-utils/src/angular/panel.ts
@@ -5,8 +5,8 @@ import {
   afterNextRender,
   inject,
   input,
-  type Type,
 } from '@angular/core'
+import type { Type } from '@angular/core'
 
 export interface DevtoolsPanelProps {
   theme?: 'dark' | 'light' | 'system'

--- a/packages/devtools-utils/src/angular/panel.ts
+++ b/packages/devtools-utils/src/angular/panel.ts
@@ -1,0 +1,65 @@
+import {
+  Component,
+  DestroyRef,
+  ElementRef,
+  afterNextRender,
+  inject,
+  input,
+  type Type,
+} from '@angular/core'
+
+export interface DevtoolsPanelProps {
+  theme?: 'dark' | 'light' | 'system'
+}
+
+export function createAngularPanel<
+  TComponentProps extends DevtoolsPanelProps,
+  TCoreDevtoolsClass extends {
+    mount: (el: HTMLElement, theme?: DevtoolsPanelProps['theme']) => void
+    unmount: () => void
+  },
+>(CoreClass: new (props: TComponentProps) => TCoreDevtoolsClass): [Type<any>, Type<any>] {
+  @Component({
+    selector: 'devtools-panel',
+    standalone: true,
+    template: '<div #panelHost style="height: 100%"></div>',
+  })
+  class Panel {
+    theme = input<DevtoolsPanelProps['theme']>()
+    devtoolsProps = input<TComponentProps>()
+
+    private hostRef = inject(ElementRef)
+    private destroyRef = inject(DestroyRef)
+    private devtools: TCoreDevtoolsClass | null = null
+
+    constructor() {
+      afterNextRender(() => {
+        const el = this.hostRef.nativeElement.querySelector('div')
+        if (!el) return
+
+        const instance = new CoreClass(
+          this.devtoolsProps() as TComponentProps,
+        )
+        this.devtools = instance
+        instance.mount(el, this.theme())
+      })
+
+      this.destroyRef.onDestroy(() => {
+        this.devtools?.unmount()
+        this.devtools = null
+      })
+    }
+  }
+
+  @Component({
+    selector: 'devtools-noop-panel',
+    standalone: true,
+    template: '',
+  })
+  class NoOpPanel {
+    theme = input<DevtoolsPanelProps['theme']>()
+    devtoolsProps = input<TComponentProps>()
+  }
+
+  return [Panel, NoOpPanel]
+}

--- a/packages/devtools-utils/src/angular/plugin.ts
+++ b/packages/devtools-utils/src/angular/plugin.ts
@@ -1,0 +1,31 @@
+import { Component, type Type } from '@angular/core'
+
+@Component({
+  selector: 'noop-component',
+  standalone: true,
+  template: '',
+})
+class NoOpComponent {}
+
+export function createAngularPlugin(
+  name: string,
+  component: Type<any>,
+) {
+  function Plugin(inputs?: Record<string, any>) {
+    return {
+      name,
+      component,
+      inputs,
+    }
+  }
+
+  function NoOpPlugin(inputs?: Record<string, any>) {
+    return {
+      name,
+      component: NoOpComponent,
+      inputs,
+    }
+  }
+
+  return [Plugin, NoOpPlugin] as const
+}

--- a/packages/devtools-utils/src/angular/plugin.ts
+++ b/packages/devtools-utils/src/angular/plugin.ts
@@ -7,10 +7,7 @@ import { Component, type Type } from '@angular/core'
 })
 class NoOpComponent {}
 
-export function createAngularPlugin(
-  name: string,
-  component: Type<any>,
-) {
+export function createAngularPlugin(name: string, component: Type<any>) {
   function Plugin(inputs?: Record<string, any>) {
     return {
       name,

--- a/packages/devtools-utils/src/angular/plugin.ts
+++ b/packages/devtools-utils/src/angular/plugin.ts
@@ -1,4 +1,5 @@
-import { Component, type Type } from '@angular/core'
+import { Component } from '@angular/core'
+import type { Type } from '@angular/core'
 
 @Component({
   selector: 'noop-component',

--- a/packages/devtools-utils/tsconfig.json
+++ b/packages/devtools-utils/tsconfig.json
@@ -12,6 +12,7 @@
     "vite.config.preact.ts",
     "vite.config.vue.ts",
     "tests",
-    "vite.config.solid.ts"
+    "vite.config.solid.ts",
+    "vite.config.angular.ts"
   ]
 }

--- a/packages/devtools-utils/vite.config.angular.ts
+++ b/packages/devtools-utils/vite.config.angular.ts
@@ -1,10 +1,9 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
-import angular from '@analogjs/vite-plugin-angular'
 import packageJson from './package.json'
 
 const config = defineConfig({
-  plugins: [angular() as any],
+  plugins: [],
   test: {
     name: packageJson.name,
     dir: './',

--- a/packages/devtools-utils/vite.config.angular.ts
+++ b/packages/devtools-utils/vite.config.angular.ts
@@ -1,0 +1,26 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import angular from '@analogjs/vite-plugin-angular'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  plugins: [angular() as any],
+  test: {
+    name: packageJson.name,
+    dir: './',
+    watch: false,
+    environment: 'jsdom',
+    setupFiles: ['./tests/test-setup.ts'],
+    globals: true,
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/angular/index.ts'],
+    srcDir: './src/angular',
+    outDir: './dist/angular',
+    cjs: false,
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.2.1(typescript@5.9.3)
       '@tanstack/vite-config':
         specifier: 0.2.1
-        version: 0.2.1(@types/node@22.15.2)(rollup@4.46.2)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
+        version: 0.2.1(@types/node@22.15.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.9.1
@@ -520,7 +520,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: latest
-        version: 3.0.1-alpha.1(@electric-sql/pglite@0.3.2)(@netlify/blobs@9.1.2)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(ioredis@5.6.1)(lru-cache@11.2.4)(mysql2@3.15.3)(rollup@4.46.2)(vite@7.3.0(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.1-alpha.1(@electric-sql/pglite@0.3.2)(@netlify/blobs@9.1.2)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(ioredis@5.6.1)(lru-cache@11.2.4)(mysql2@3.15.3)(rollup@4.59.0)(vite@7.3.0(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -694,6 +694,31 @@ importers:
         specifier: ^7.1.7
         version: 7.2.6(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
+  packages/angular-devtools:
+    dependencies:
+      '@tanstack/devtools':
+        specifier: workspace:*
+        version: link:../devtools
+    devDependencies:
+      '@angular/compiler':
+        specifier: ^20.0.0
+        version: 20.3.17
+      '@angular/compiler-cli':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)
+      '@angular/core':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/platform-browser-dynamic':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))
+      zone.js:
+        specifier: ^0.15.0
+        version: 0.15.1
+
   packages/devtools:
     dependencies:
       '@solid-primitives/event-listener':
@@ -777,6 +802,18 @@ importers:
         specifier: '>=3.2.0'
         version: 3.5.25(typescript@5.9.3)
     devDependencies:
+      '@angular/compiler':
+        specifier: ^20.0.0
+        version: 20.3.17
+      '@angular/compiler-cli':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)
+      '@angular/core':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser':
+        specifier: ^20.0.0
+        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.4))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.1)
@@ -949,6 +986,61 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@angular/common@19.2.19':
+    resolution: {integrity: sha512-/JYo8jJZ6BAgw3IVYJpinAfGb+RbaZubrElFvaq450BWxDPInv7Z99HKEQ3qEBRsBeIAQ/WrKXDxoJSjy7QMNQ==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/core': 19.2.19
+      rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/compiler-cli@20.3.17':
+    resolution: {integrity: sha512-w5pmO1pXO9tUMgUMWstpDmAWh5s1lJWo+2GI/ByaUEgBZkXd2S92sWoDL+bhy+JSvFzdLGdua6BncHBOX7hEjA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@angular/compiler': 20.3.17
+      typescript: '>=5.8 <6.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@angular/compiler@20.3.17':
+    resolution: {integrity: sha512-cj3x6aFk9xOOxX+qEdeN8T5YbnBNWJ4UMHB/LQoDr7/xCJJGa40IhcOAuJeuF2kGqTwx6MCXnvjO8XOQfHhe9g==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@angular/core@20.3.17':
+    resolution: {integrity: sha512-YlQqxMeHI9XJw7I7oM3hYFQd4lQbK37IdlD9ztROIw5FjX6i6lmLU7+X1MQGSRi2r+X9l3IZtl33hRTNvkoUBw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/compiler': 20.3.17
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0
+    peerDependenciesMeta:
+      '@angular/compiler':
+        optional: true
+      zone.js:
+        optional: true
+
+  '@angular/platform-browser-dynamic@20.3.17':
+    resolution: {integrity: sha512-yTxFuGQ+z0J9khNIhfFZ+kkT7TOFb8kFZKyUz0DxHOmE0q/TEvNZoy3jXOs8xCBFf1+6BY0NqFNlPna+uw36FQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/common': 20.3.17
+      '@angular/compiler': 20.3.17
+      '@angular/core': 20.3.17
+      '@angular/platform-browser': 20.3.17
+
+  '@angular/platform-browser@20.3.17':
+    resolution: {integrity: sha512-GA8pK+0F2/KGdYn5LMpLBrPTkQUwGjQE8Q+qsivOa150cK3OuD0po5PvYK58l+niGIVvm0wB1xGKTHTOiX/+4A==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/animations': 20.3.17
+      '@angular/common': 20.3.17
+      '@angular/core': 20.3.17
+    peerDependenciesMeta:
+      '@angular/animations':
+        optional: true
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -986,6 +1078,10 @@ packages:
 
   '@babel/compat-data@7.28.0':
     resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.3':
+    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.28.5':
@@ -3182,8 +3278,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.46.2':
     resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
     cpu: [arm64]
     os: [android]
 
@@ -3192,8 +3298,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.46.2':
     resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
     cpu: [x64]
     os: [darwin]
 
@@ -3202,8 +3318,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.46.2':
     resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
 
@@ -3212,8 +3338,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
 
@@ -3222,9 +3358,29 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
@@ -3237,8 +3393,23 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
 
@@ -3247,8 +3418,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
 
@@ -3257,13 +3438,38 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
     cpu: [arm64]
     os: [win32]
 
@@ -3272,8 +3478,23 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.46.2':
     resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
 
@@ -4896,6 +5117,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -4995,6 +5220,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -8121,6 +8349,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   regex-recursion@5.1.1:
     resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
 
@@ -8282,6 +8513,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rou3@0.7.10:
     resolution: {integrity: sha512-aoFj6f7MJZ5muJ+Of79nrhs9N3oLGqi2VEMe94Zbkjb6Wupha46EuoYgpWSOZlXww3bbd8ojgXTAA2mzimX5Ww==}
 
@@ -8297,6 +8533,9 @@ packages:
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -9756,9 +9995,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -9809,6 +10056,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zone.js@0.15.1:
+    resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
+
   zustand@5.0.9:
     resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==}
     engines: {node: '>=12.20.0'}
@@ -9842,6 +10092,54 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)':
+    dependencies:
+      '@angular/compiler': 20.3.17
+      '@babel/core': 7.28.3
+      '@jridgewell/sourcemap-codec': 1.5.5
+      chokidar: 4.0.3
+      convert-source-map: 1.9.0
+      reflect-metadata: 0.2.2
+      semver: 7.7.3
+      tslib: 2.8.1
+      yargs: 18.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@angular/compiler@20.3.17':
+    dependencies:
+      tslib: 2.8.1
+
+  '@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@angular/compiler': 20.3.17
+      zone.js: 0.15.1
+
+  '@angular/platform-browser-dynamic@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))':
+    dependencies:
+      '@angular/common': 19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler': 20.3.17
+      '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
+      tslib: 2.8.1
+
+  '@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))':
+    dependencies:
+      '@angular/common': 19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
+      tslib: 2.8.1
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -9901,6 +10199,26 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.28.0': {}
+
+  '@babel/core@7.28.3':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@7.28.5':
     dependencies:
@@ -9972,6 +10290,15 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11940,34 +12267,78 @@ snapshots:
     optionalDependencies:
       rollup: 4.46.2
 
+  '@rollup/pluginutils@5.1.4(rollup@4.59.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.59.0
+
   '@rollup/rollup-android-arm-eabi@4.46.2':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.46.2':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.46.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.46.2':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
@@ -11976,28 +12347,67 @@ snapshots:
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.46.2':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.46.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
   '@rushstack/node-core-library@5.7.0(@types/node@22.15.2)':
@@ -13002,10 +13412,10 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.141.0': {}
 
-  '@tanstack/vite-config@0.2.1(@types/node@22.15.2)(rollup@4.46.2)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))':
+  '@tanstack/vite-config@0.2.1(@types/node@22.15.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))':
     dependencies:
-      rollup-plugin-preserve-directives: 0.4.0(rollup@4.46.2)
-      vite-plugin-dts: 4.2.3(@types/node@22.15.2)(rollup@4.46.2)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
+      rollup-plugin-preserve-directives: 0.4.0(rollup@4.59.0)
+      vite-plugin-dts: 4.2.3(@types/node@22.15.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
       vite-plugin-externalize-deps: 0.9.0(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
       vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -14199,6 +14609,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.0
+
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
@@ -14277,6 +14693,8 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
+
+  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -17123,7 +17541,7 @@ snapshots:
 
   nf3@0.1.12: {}
 
-  nitro@3.0.1-alpha.1(@electric-sql/pglite@0.3.2)(@netlify/blobs@9.1.2)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(ioredis@5.6.1)(lru-cache@11.2.4)(mysql2@3.15.3)(rollup@4.46.2)(vite@7.3.0(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
+  nitro@3.0.1-alpha.1(@electric-sql/pglite@0.3.2)(@netlify/blobs@9.1.2)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(ioredis@5.6.1)(lru-cache@11.2.4)(mysql2@3.15.3)(rollup@4.59.0)(vite@7.3.0(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.1(srvx@0.9.8)
@@ -17140,7 +17558,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.4(@netlify/blobs@9.1.2)(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.16.3)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.6.1)(lru-cache@11.2.4)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
-      rollup: 4.46.2
+      rollup: 4.59.0
       vite: 7.3.0(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -18013,6 +18431,8 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reflect-metadata@0.2.2: {}
+
   regex-recursion@5.1.1:
     dependencies:
       regex: 5.1.1
@@ -18201,11 +18621,11 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.32
     optional: true
 
-  rollup-plugin-preserve-directives@0.4.0(rollup@4.46.2):
+  rollup-plugin-preserve-directives@0.4.0(rollup@4.59.0):
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
+      '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
       magic-string: 0.30.21
-      rollup: 4.46.2
+      rollup: 4.59.0
 
   rollup-plugin-visualizer@6.0.3(rolldown@1.0.0-beta.32)(rollup@4.46.2):
     dependencies:
@@ -18243,6 +18663,37 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
   rou3@0.7.10: {}
 
   roughjs@4.6.6:
@@ -18259,6 +18710,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   rw@1.3.3: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   sade@1.8.1:
     dependencies:
@@ -19391,10 +19846,10 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.2.3(@types/node@22.15.2)(rollup@4.46.2)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
+  vite-plugin-dts@4.2.3(@types/node@22.15.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.2.6(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.47.7(@types/node@22.15.2)
-      '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
+      '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
       '@volar/typescript': 2.4.13
       '@vue/language-core': 2.1.6(typescript@5.9.3)
       compare-versions: 6.1.1
@@ -19961,6 +20416,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -19970,6 +20427,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:
@@ -20025,6 +20491,8 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zone.js@0.15.1: {}
 
   zustand@5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,6 +696,9 @@ importers:
 
   packages/angular-devtools:
     dependencies:
+      '@angular/platform-browser':
+        specifier: '>=19.0.0'
+        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
       '@tanstack/devtools':
         specifier: workspace:*
         version: link:../devtools
@@ -703,21 +706,9 @@ importers:
       '@angular/compiler':
         specifier: ^20.0.0
         version: 20.3.17
-      '@angular/compiler-cli':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)
       '@angular/core':
         specifier: ^20.0.0
         version: 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
-      '@angular/platform-browser-dynamic':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))
-      zone.js:
-        specifier: ^0.15.0
-        version: 0.15.1
 
   packages/devtools:
     dependencies:
@@ -783,6 +774,9 @@ importers:
 
   packages/devtools-utils:
     dependencies:
+      '@angular/core':
+        specifier: '>=19.0.0'
+        version: 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@tanstack/devtools-ui':
         specifier: workspace:^
         version: link:../devtools-ui
@@ -802,18 +796,6 @@ importers:
         specifier: '>=3.2.0'
         version: 3.5.25(typescript@5.9.3)
     devDependencies:
-      '@angular/compiler':
-        specifier: ^20.0.0
-        version: 20.3.17
-      '@angular/compiler-cli':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)
-      '@angular/core':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser':
-        specifier: ^20.0.0
-        version: 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.4))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.1)
@@ -993,17 +975,6 @@ packages:
       '@angular/core': 19.2.19
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/compiler-cli@20.3.17':
-    resolution: {integrity: sha512-w5pmO1pXO9tUMgUMWstpDmAWh5s1lJWo+2GI/ByaUEgBZkXd2S92sWoDL+bhy+JSvFzdLGdua6BncHBOX7hEjA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@angular/compiler': 20.3.17
-      typescript: '>=5.8 <6.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@angular/compiler@20.3.17':
     resolution: {integrity: sha512-cj3x6aFk9xOOxX+qEdeN8T5YbnBNWJ4UMHB/LQoDr7/xCJJGa40IhcOAuJeuF2kGqTwx6MCXnvjO8XOQfHhe9g==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1020,15 +991,6 @@ packages:
         optional: true
       zone.js:
         optional: true
-
-  '@angular/platform-browser-dynamic@20.3.17':
-    resolution: {integrity: sha512-yTxFuGQ+z0J9khNIhfFZ+kkT7TOFb8kFZKyUz0DxHOmE0q/TEvNZoy3jXOs8xCBFf1+6BY0NqFNlPna+uw36FQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 20.3.17
-      '@angular/compiler': 20.3.17
-      '@angular/core': 20.3.17
-      '@angular/platform-browser': 20.3.17
 
   '@angular/platform-browser@20.3.17':
     resolution: {integrity: sha512-GA8pK+0F2/KGdYn5LMpLBrPTkQUwGjQE8Q+qsivOa150cK3OuD0po5PvYK58l+niGIVvm0wB1xGKTHTOiX/+4A==}
@@ -1078,10 +1040,6 @@ packages:
 
   '@babel/compat-data@7.28.0':
     resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.28.3':
-    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.28.5':
@@ -5117,10 +5075,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -5220,9 +5174,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -8349,9 +8300,6 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
-  reflect-metadata@0.2.2:
-    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
-
   regex-recursion@5.1.1:
     resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
 
@@ -9995,17 +9943,9 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -10099,22 +10039,6 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.9.3)':
-    dependencies:
-      '@angular/compiler': 20.3.17
-      '@babel/core': 7.28.3
-      '@jridgewell/sourcemap-codec': 1.5.5
-      chokidar: 4.0.3
-      convert-source-map: 1.9.0
-      reflect-metadata: 0.2.2
-      semver: 7.7.3
-      tslib: 2.8.1
-      yargs: 18.0.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@angular/compiler@20.3.17':
     dependencies:
       tslib: 2.8.1
@@ -10126,14 +10050,6 @@ snapshots:
     optionalDependencies:
       '@angular/compiler': 20.3.17
       zone.js: 0.15.1
-
-  '@angular/platform-browser-dynamic@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))':
-    dependencies:
-      '@angular/common': 19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/compiler': 20.3.17
-      '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
-      tslib: 2.8.1
 
   '@angular/platform-browser@20.3.17(@angular/common@19.2.19(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))':
     dependencies:
@@ -10199,26 +10115,6 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.28.0': {}
-
-  '@babel/core@7.28.3':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.28.5':
     dependencies:
@@ -10290,15 +10186,6 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14609,12 +14496,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 9.0.0
-
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
@@ -14693,8 +14574,6 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
-
-  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -18431,8 +18310,6 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
-  reflect-metadata@0.2.2: {}
-
   regex-recursion@5.1.1:
     dependencies:
       regex: 5.1.1
@@ -20416,8 +20293,6 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -20427,15 +20302,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:
@@ -20492,7 +20358,8 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zone.js@0.15.1: {}
+  zone.js@0.15.1:
+    optional: true
 
   zustand@5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add new `@tanstack/angular-devtools` package — a standalone Angular 19+ component wrapping `TanStackDevtoolsCore` with signal-based inputs, dynamic component rendering via `createComponent` + `ApplicationRef.attachView`, and reactive config updates via `effect()`
- Add `@tanstack/devtools-utils/angular` export with `createAngularPlugin()` and `createAngularPanel()` factory functions following the `[Plugin, NoOpPlugin]` tuple pattern
- Includes full build configuration, type declarations, and publint verification

## Test plan
- [x] `pnpm build:all` passes (all packages including angular)
- [x] `test:types` passes for both angular-devtools and devtools-utils
- [x] `test:build` (publint --strict) passes for angular-devtools
- [x] Dist outputs verified: correct ESM exports, type declarations generated