### PR TITLE
Update installation command for devtools to dev dependency

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,7 @@ TanStack Devtools is a framework-agnostic devtool for managing and debugging dev
 Install the devtools and the Vite plugin:
 
 ```bash
-npm install @tanstack/react-devtools @tanstack/devtools-vite
+npm install -D @tanstack/react-devtools @tanstack/devtools-vite
 ```
 
 Add the `TanStackDevtools` component to the root of your application:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -65,7 +65,7 @@ createRoot(document.getElementById('root')!).render(
 Install the devtools and the Vite plugin:
 
 ```bash
-npm install @tanstack/preact-devtools @tanstack/devtools-vite
+npm install -D @tanstack/preact-devtools @tanstack/devtools-vite
 ```
 
 Add the `TanStackDevtools` component using Preact's `render()` function:
@@ -114,7 +114,7 @@ render(
 Install the devtools and the Vite plugin:
 
 ```bash
-npm install @tanstack/solid-devtools @tanstack/devtools-vite
+npm install -D @tanstack/solid-devtools @tanstack/devtools-vite
 ```
 
 Add the `TanStackDevtools` component using Solid's `render(() => ...)` pattern:
@@ -167,7 +167,7 @@ render(() => (
 Install the Vue devtools adapter:
 
 ```bash
-npm install @tanstack/vue-devtools
+npm install -D @tanstack/vue-devtools
 ```
 
 > The Vite plugin (`@tanstack/devtools-vite`) is optional for Vue but recommended if you want features like enhanced console logs and go-to-source.


### PR DESCRIPTION
## 🎯 Changes

add `-D` to install command in quick start to match the instructions on the installation page

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [-] (N/A) I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated devtools installation instructions: React, Preact, Solid, and Vue devtools (and their Vite plugins) are now shown as development dependencies (npm install -D).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->