### PR TITLE
fix:duplicate Devtools UI rendering when React StrictMode is enabled

### DIFF
--- a/.changeset/legal-trains-throw.md
+++ b/.changeset/legal-trains-throw.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools': patch
+---
+
+Fix duplicate Devtools UI rendering when React StrictMode is enabled.

--- a/packages/devtools/src/core.ts
+++ b/packages/devtools/src/core.ts
@@ -40,9 +40,8 @@ export class TanStackDevtoolsCore {
     ...initialState.settings,
   }
   #plugins: Array<TanStackDevtoolsPlugin> = []
-  #isMounted = false
-  #isMounting = false
-  #abortMount = false
+  #state: 'mounted' | 'mounting' | 'unmounted' = 'unmounted'
+  #mountAbortController?: AbortController
   #dispose?: () => void
   #eventBus?: { stop: () => void }
   #eventBusConfig: ClientEventBusConfig | undefined
@@ -60,16 +59,15 @@ export class TanStackDevtoolsCore {
   mount<T extends HTMLElement>(el: T) {
     if (typeof document === 'undefined') return
 
-    if (this.#isMounted || this.#isMounting) {
+    if (this.#state === 'mounted' || this.#state === 'mounting') {
       throw new Error('Devtools is already mounted')
     }
-    this.#isMounting = true
-    this.#abortMount = false
+    this.#state = 'mounting'
+    const { signal } = (this.#mountAbortController = new AbortController())
 
     import('./mount-impl')
       .then(({ mountDevtools }) => {
-        if (this.#abortMount) {
-          this.#isMounting = false
+        if (signal.aborted) {
           return
         }
 
@@ -85,27 +83,22 @@ export class TanStackDevtoolsCore {
 
         this.#dispose = result.dispose
         this.#eventBus = result.eventBus
-        this.#isMounted = true
-        this.#isMounting = false
+        this.#state = 'mounted'
       })
       .catch((err) => {
-        this.#isMounting = false
+        this.#state = 'unmounted'
         console.error('[TanStack Devtools] Failed to load:', err)
       })
   }
 
   unmount() {
-    if (!this.#isMounted && !this.#isMounting) {
+    if (this.#state === 'unmounted') {
       throw new Error('Devtools is not mounted')
     }
-    if (this.#isMounting) {
-      this.#abortMount = true
-      this.#isMounting = false
-      return
-    }
+    this.#mountAbortController?.abort()
     this.#eventBus?.stop()
     this.#dispose?.()
-    this.#isMounted = false
+    this.#state = 'unmounted'
   }
 
   setConfig(config: Partial<TanStackDevtoolsInit>) {
@@ -116,7 +109,7 @@ export class TanStackDevtoolsCore {
     if (config.plugins) {
       this.#plugins = config.plugins
       // Update the reactive store if mounted
-      if (this.#isMounted && this.#setPlugins) {
+      if (this.#state === 'mounted' && this.#setPlugins) {
         this.#setPlugins(config.plugins)
       }
     }


### PR DESCRIPTION

fixes #402, fixes #391

## 🎯 Changes

Previous implementation used separate boolean flags (`#isMounted`, `#isMounting`, `#abortMount`) to track state, which led to race conditions in `StrictMode`. When `mount()`, `unmount()` and `mount()` were rapidly called, the second `mount()` would reset the state flags before the first import had a chance to complete its abort check.

I've replaced that with `AbortController` and `#state` union to also eliminate illegal state (i.e. `#isMounted = true` and `#isMounting = true`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Devtools UI rendering when React StrictMode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->