### PR TITLE
fix(devtools-vite): prevent console pipe loop and solid-js duplication

### DIFF
--- a/.changeset/twenty-impalas-poke.md
+++ b/.changeset/twenty-impalas-poke.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-vite': patch
+---
+
+Fix console pipe feedback loop and solid-js duplication with Vite 8

--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -146,7 +146,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           return
         }
 
-        /*  const solidDedupeDeps = [
+        const solidDedupeDeps = [
           'solid-js',
           'solid-js/web',
           'solid-js/store',
@@ -161,7 +161,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           optimizeDeps: {
             include: solidDedupeDeps,
           },
-        } */
+        }
       },
     },
     {
@@ -223,6 +223,10 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           await editor.open(path, lineNum, columnNum)
         }
 
+        const originalConsole = Object.fromEntries(
+          consolePipingLevels.map((l) => [l, console[l].bind(console)]),
+        ) as Record<ConsoleLevel, typeof console.log>
+
         // SSE clients for broadcasting server logs to browser
         const sseClients: Array<{
           res: ServerResponse
@@ -248,7 +252,8 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
                   onConsolePipe: (entries) => {
                     for (const entry of entries) {
                       const prefix = chalk.cyan('[Client]')
-                      const logMethod = console[entry.level as ConsoleLevel]
+                      const logMethod =
+                        originalConsole[entry.level as ConsoleLevel]
                       const cleanedArgs = stripEnhancedLogPrefix(
                         entry.args,
                         (loc) => chalk.gray(loc),

--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -146,7 +146,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           return
         }
 
-        /* const solidDedupeDeps = [
+        /*  const solidDedupeDeps = [
           'solid-js',
           'solid-js/web',
           'solid-js/store',

--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -146,7 +146,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           return
         }
 
-        const solidDedupeDeps = [
+        /* const solidDedupeDeps = [
           'solid-js',
           'solid-js/web',
           'solid-js/store',
@@ -161,7 +161,7 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
           optimizeDeps: {
             include: solidDedupeDeps,
           },
-        }
+        } */
       },
     },
     {

--- a/packages/devtools-vite/src/plugin.ts
+++ b/packages/devtools-vite/src/plugin.ts
@@ -253,7 +253,8 @@ export const devtools = (args?: TanStackDevtoolsViteConfig): Array<Plugin> => {
                     for (const entry of entries) {
                       const prefix = chalk.cyan('[Client]')
                       const logMethod =
-                        originalConsole[entry.level as ConsoleLevel]
+                        originalConsole[entry.level as ConsoleLevel] ||
+                        originalConsole.log
                       const cleanedArgs = stripEnhancedLogPrefix(
                         entry.args,
                         (loc) => chalk.gray(loc),


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
 
Two fixes for Vite 8 compatibility in `@tanstack/devtools-vite` referenced in #411 :

  - Uncomment `resolve.dedupe` for solid-js dependencies during serve mode, Vite 8's Rolldown bundler resolves solid-js as duplicate instances, causing "multiple instances" warnings to fire.
  - Save original console methods before piping wraps them and use those in `onConsolePipe`. In SSR frameworks (e.g. TanStack Start) where the SSR server shares the Vite dev server process, the injected piping code wraps console globally. When `onConsolePipe` calls `console[level]()` it hits the wrapped version instead of the original, causing piped messages to be re-piped.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a console pipe feedback loop that could cause repeated logging.
  * Resolved Solid.js duplication issues when using Vite 8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->