### PR TITLE
improve devtools-app-setup skill description for better agent matching

### DIFF
--- a/packages/devtools/skills/devtools-app-setup/SKILL.md
+++ b/packages/devtools/skills/devtools-app-setup/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: devtools-app-setup
-description: >
-  Install TanStack Devtools, pick framework adapter (React/Vue/Solid/Preact),
-  register plugins via plugins prop, configure shell (position, hotkeys, theme,
-  hideUntilHover, requireUrlFlag, eventBusConfig). TanStackDevtools component,
-  defaultOpen, localStorage persistence.
+description: >-
+  Install and configure TanStack Devtools - pick framework adapter (React/Vue/Solid/Preact), register plugins via plugins prop, configure shell (position, hotkeys, theme, hideUntilHover, requireUrlFlag, eventBusConfig). Use when setting up TanStack Devtools, adding devtools to a project, configuring the devtools shell, or when the user says "add devtools", "setup TanStack Devtools", "configure devtools panel".
 type: core
 library: '@tanstack/devtools'
 library_version: '0.10.12'


### PR DESCRIPTION
hey @TanStack, thanks for building the devtools framework. really like the framework-agnostic plugin architecture. kudos on passing `440` stars! just starred it.

ran your devtools-app-setup skill through some evals and noticed a few things that were pretty quick to improve (moving from `~68%` to `~88%` agent performance):

- expanded description with trigger terms like _add devtools_, _setup TanStack Devtools_, _configure devtools panel_ for better agent matching

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `9` skills here, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced DevTools skill description to clearly outline supported use cases and user intents for setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->