### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Tools
         uses: TanStack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Fix formatting

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # review job pushes a generated branch
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -121,7 +121,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit --allow-empty -m "chore: review stale skills for ${VERSION}"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH"
+          git push origin "$BRANCH"
 
           node <<'NODE'
           const fs = require('fs')

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -123,25 +123,17 @@ jobs:
           git commit --allow-empty -m "chore: review stale skills for ${VERSION}"
           git push origin "$BRANCH"
 
-          node <<'NODE'
-          const fs = require('fs')
-          fs.writeFileSync('pr-body.md', `## Stale Skills Detected
-
-          The following skills may need updates after the latest release:
-
-          ${process.env.SUMMARY}
-
-          ---
-
-          ### Update Prompt
-
-          Paste this into your coding agent (Claude Code, Cursor, etc.):
-
-          ~~~
-          ${process.env.PROMPT}
-          ~~~
-          `)
-          NODE
+          {
+            printf '%s\n\n' '## Stale Skills Detected'
+            printf '%s\n\n' 'The following skills may need updates after the latest release:'
+            printf '%s\n\n' "$SUMMARY"
+            printf '%s\n\n' '---'
+            printf '%s\n\n' '### Update Prompt'
+            printf '%s\n\n' 'Paste this into your coding agent (Claude Code, Cursor, etc.):'
+            printf '%s\n' '~~~'
+            printf '%s\n' "$PROMPT"
+            printf '%s\n' '~~~'
+          } > pr-body.md
 
           gh pr create \
             --title "Review stale skills (${VERSION})" \

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -17,18 +17,21 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check:
     name: Check for stale skills
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -108,24 +111,25 @@ jobs:
         if: steps.stale.outputs.has_stale == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name || 'manual' }}
+          SUMMARY: ${{ steps.summary.outputs.summary }}
+          PROMPT: ${{ steps.summary.outputs.prompt }}
         run: |
-          VERSION="${{ github.event.release.tag_name || 'manual' }}"
           BRANCH="skills/review-${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit --allow-empty -m "chore: review stale skills for ${VERSION}"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH"
 
-          gh pr create \
-            --title "Review stale skills (${VERSION})" \
-            --body "$(cat <<'PREOF'
-          ## Stale Skills Detected
+          node <<'NODE'
+          const fs = require('fs')
+          fs.writeFileSync('pr-body.md', `## Stale Skills Detected
 
           The following skills may need updates after the latest release:
 
-          ${{ steps.summary.outputs.summary }}
+          ${process.env.SUMMARY}
 
           ---
 
@@ -134,10 +138,13 @@ jobs:
           Paste this into your coding agent (Claude Code, Cursor, etc.):
 
           ~~~
-          ${{ steps.summary.outputs.prompt }}
+          ${process.env.PROMPT}
           ~~~
+          `)
+          NODE
 
-          PREOF
-          )" \
+          gh pr create \
+            --title "Review stale skills (${VERSION})" \
+            --body-file pr-body.md \
             --head "$BRANCH" \
             --base main

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,15 +9,19 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   review:
     name: Review dependency changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@e58c696e52cac8e62d61cc21fda89565d71505d7 # v4.3.1

--- a/.github/workflows/notify-playbooks.yml
+++ b/.github/workflows/notify-playbooks.yml
@@ -22,6 +22,9 @@ on:
       - 'docs/**'
       - 'packages/*/src/**'
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     name: Notify TanStack Intent
@@ -31,6 +34,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Collect changed files
         id: changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,21 +12,24 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Tools
         uses: TanStack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Get base and head commits for `nx affected`
-        uses: nrwl/nx-set-shas@15514ee4353489ef5a1644bcdae44f0ae2ea45f3 # v4.4.0
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
         with:
           main-branch-name: main
       - name: Run Checks
@@ -37,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Tools
         uses: TanStack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Build Packages
@@ -49,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check Provenance
         uses: danielroe/provenance-action@41bcc969e579d9e29af08ba44fcbfdf95cee6e6c # v0.1.1
         with:
@@ -59,6 +66,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Tools
         uses: TanStack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Changeset Preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,17 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release:
     name: Release
     if: github.repository_owner == 'TanStack'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     # Configure required reviewers / wait timer for this environment in
     # repo settings → Environments → release. Until configured, this only
     # creates a deployment record (no gating).
@@ -32,13 +34,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Tools
         uses: TanStack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Run Tests
         run: pnpm run test:ci
       - name: Run Changesets (version or publish)
         id: changesets
-        uses: changesets/action@e87c8ed249971350e47fab7515075f44eb134e5b # v1.7.0
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm run changeset:version
           publish: pnpm run changeset:publish

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -11,9 +11,11 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Triage issue with Warp Agent
-        uses: warpdotdev/warp-agent-action@039f8de15fe60704b4308850e8cafb5cc0958bf2 # v1
+        uses: warpdotdev/warp-agent-action@fee7dc8441f64d14a4ae22596eb68167ced24a1a # v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
 
       - name: Triage issue with Warp Agent
-        uses: warpdotdev/warp-agent-action@fee7dc8441f64d14a4ae22596eb68167ced24a1a # v1
+        uses: warpdotdev/warp-agent-action@fee7dc8441f64d14a4ae22596eb68167ced24a1a # v1.0.18
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -12,6 +12,9 @@ on:
       - 'skills/**'
       - '**/skills/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate skill files
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary
- Add a pinned zizmor GitHub Actions security analysis workflow.
- Harden existing workflows for zizmor findings by disabling persisted checkout credentials, narrowing write permissions, and avoiding direct expression interpolation in shell scripts.
