### PR TITLE
security: stricter pnpm config blockExoticSubdeps & trustPolicy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,18 +48,6 @@ jobs:
         run: pnpm run build:all
       - name: Publish Previews
         run: pnpx pkg-pr-new@0.0.71 publish --pnpm './packages/*' --template './examples/*/*'
-  provenance:
-    name: Provenance
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Check Provenance
-        uses: danielroe/provenance-action@41bcc969e579d9e29af08ba44fcbfdf95cee6e6c # v0.1.1
-        with:
-          fail-on-downgrade: true
   version-preview:
     name: Version Preview
     runs-on: ubuntu-latest

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+blockExoticSubdeps: true
+trustPolicy: 'no-downgrade'
 
 packages:
   - examples/**/*


### PR DESCRIPTION
Enables pnpm's no-downgrade trust policy and blocks exotic transitive dependencies via pnpm workspace security settings.

Removes the redundant standalone danielroe/provenance-action downgrade CI job from the PR workflow.