### PR TITLE
fix(devtools-vite): preserve valid syntax when removing parenthesized devtools JSX

### DIFF
--- a/.changeset/small-papers-wink.md
+++ b/.changeset/small-papers-wink.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-vite': patch
+---
+
+Fix invalid syntax generated when removing parenthesized devtools JSX expressions.

--- a/packages/devtools-vite/src/ast-utils.ts
+++ b/packages/devtools-vite/src/ast-utils.ts
@@ -48,7 +48,11 @@ export function forEachChild(node: Node, callback: (child: Node) => void) {
 /**
  * Recursively walk AST nodes, calling `visitor` for each node with a `type`.
  */
-export function walk(node: Node, visitor: (node: Node) => void) {
-  visitor(node)
-  forEachChild(node, (child) => walk(child, visitor))
+export function walk(
+  node: Node,
+  visitor: (node: Node, parentNode?: Node) => void,
+  parentNode?: Node,
+) {
+  visitor(node, parentNode)
+  forEachChild(node, (child) => walk(child, visitor, node))
 }

--- a/packages/devtools-vite/src/remove-devtools.test.ts
+++ b/packages/devtools-vite/src/remove-devtools.test.ts
@@ -577,4 +577,31 @@ export default function App() {
       expect(output!.code).not.toContain('TanStackDevtools')
     })
   })
+
+  test('preserves valid syntax when removing parenthesized devtools return', () => {
+    const output = removeEmptySpace(
+      removeDevtools(
+        `
+import { TanStackDevtools } from '@tanstack/react-devtools'
+
+export function DevtoolsProvider() {
+  return (
+    <TanStackDevtools />
+  )
+}
+`,
+        'test.tsx',
+      )!.code,
+    )
+
+    expect(output).toBe(
+      removeEmptySpace(`
+export function DevtoolsProvider() {
+  return (
+    null
+  )
+}
+`),
+    )
+  })
 })

--- a/packages/devtools-vite/src/remove-devtools.ts
+++ b/packages/devtools-vite/src/remove-devtools.ts
@@ -105,7 +105,7 @@ export function removeDevtools(code: string, id: string) {
     if (devtoolsNames.size === 0) return
 
     // Pass 2: Find and remove devtools JSX elements, collect plugin references
-    walk(result.program, (node) => {
+    walk(result.program, (node, parentNode) => {
       if (node.type !== 'JSXElement') return
 
       const opening = node.openingElement
@@ -130,7 +130,11 @@ export function removeDevtools(code: string, id: string) {
 
       let end = node.end
       if (code[end] === '\n') end++
-      s.remove(node.start, end)
+      if (parentNode?.type === 'ParenthesizedExpression') {
+        s.overwrite(node.start, end, 'null')
+      } else {
+        s.remove(node.start, end)
+      }
     })
 
     // Pass 3: Remove plugin imports that are no longer referenced


### PR DESCRIPTION
## 🎯 Changes

Fixes an issue where removing devtools JSX could leave behind an invalid empty parenthesized expression.

Example:

Before transform:

```tsx
return (
  <TanStackDevtools />
)
````

Generated output:

```tsx
return (
);
```

This PR replaces the removed JSX with `null` to preserve valid syntax:

```tsx
return (
  null
)
```

Closes #444 


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed syntax errors when removing devtools components from certain code patterns.

* **Tests**
  * Added test case for removing devtools components in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/devtools/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->