### PR TITLE
fix: fix go to source file whose path contains $ symbol

### DIFF
--- a/.changeset/floppy-mammals-write.md
+++ b/.changeset/floppy-mammals-write.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-vite': patch
+---
+
+fix go to source file whose path contains $ symbol

--- a/packages/devtools-vite/src/editor.ts
+++ b/packages/devtools-vite/src/editor.ts
@@ -28,7 +28,7 @@ export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
   open: async (path, lineNumber, columnNumber) => {
     const launch = (await import('launch-editor')).default
     launch(
-      `${path.replaceAll('$', '\\$')}${lineNumber ? `:${lineNumber}` : ''}${columnNumber ? `:${columnNumber}` : ''}`,
+      `${path}${lineNumber ? `:${lineNumber}` : ''}${columnNumber ? `:${columnNumber}` : ''}`,
       undefined,
       (filename, err) => {
         console.warn(`Failed to open ${filename} in editor: ${err}`)


### PR DESCRIPTION
## 🎯 Changes

Fix `@tanstack/devtools-vite` click-to-code for source files whose paths contain `$`. The previous implementation escaped `$` before passing the path to `launch-editor` which turns a real path e.g. `src/routes/$postId.tsx` into `src/routes/\$postId.tsx`. `launch-editor` checks `fs.existsSync(fileName)` before spawning the editor, so the escaped path fails existence checks.

Verified locally by:
- building `@tanstack/devtools-vite`
- linking the local package into an app with TanStack router
- confirming click-to-code now opens `$...` route files correctly in both VS Code and IntelliJ

I am not sure why this wasn't reported before since TanStack Router makes heavy use of `$` in file path. I believe my fix is independent of OS and editor, please point out if the fix is wrong.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where opening source files in the editor failed when file paths contained the dollar sign ($), ensuring "go to source" works reliably.
* **Chores**
  * Updated release metadata to publish a patch with the above fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/devtools/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->