### PR TITLE
fix(devtools): allow plugin panel roots to scroll

### DIFF
--- a/.changeset/router-plugin-scroll.md
+++ b/.changeset/router-plugin-scroll.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools': patch
+---
+
+Allow direct-mounted plugin panels to inherit full height for embedded scrolling.

--- a/packages/devtools/src/styles/use-styles.ts
+++ b/packages/devtools/src/styles/use-styles.ts
@@ -664,10 +664,20 @@ const stylesFactory = (theme: DevtoolsStore['settings']['theme']) => {
     pluginsTabContent: css`
       width: 100%;
       height: 100%;
+      min-width: 0;
+      min-height: 0;
+
+      & > * {
+        min-width: 0;
+        min-height: 0;
+        width: 100%;
+        height: 100%;
+      }
 
       & > * > * {
         min-width: 0;
         min-height: 0;
+        width: 100%;
         height: 100%;
       }
 


### PR DESCRIPTION
Fixes #454

## Summary
- give plugin panel containers explicit min-width/min-height constraints
- apply the same full-size constraints to direct-mounted plugin roots that already existed for nested plugin content
- add a patch changeset for `@tanstack/devtools`

## Test plan
- `CI=true corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @tanstack/devtools-ui build`
- `corepack pnpm --filter @tanstack/devtools-event-bus build`
- `corepack pnpm --filter @tanstack/devtools-event-client build`
- `corepack pnpm --filter @tanstack/devtools-client build`
- `corepack pnpm --filter @tanstack/devtools test:eslint`
- `corepack pnpm --filter @tanstack/devtools test:lib -- --run`
- `corepack pnpm --filter @tanstack/devtools test:types`
- `corepack pnpm --filter @tanstack/devtools build`
- `corepack pnpm test:knip`
- `corepack pnpm test:sherif`
- `corepack pnpm exec prettier --check packages/devtools/src/styles/use-styles.ts .changeset/router-plugin-scroll.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout and scrolling behavior for embedded plugin panels
  * Improved sizing constraints to prevent content overflow in plugin panel displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->