### PR TITLE
Add bugs.url package metadata

### DIFF
--- a/packages/devtools-vite/package.json
+++ b/packages/devtools-vite/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-vite"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@tanstack/devtools-vite`
- updates only `packages/devtools-vite/package.json`

## Metadata added
- `bugs.url`: `https://github.com/TanStack/devtools/issues`

## Validation
- parsed `packages/devtools-vite/package.json` as JSON after the change
- confirmed the changed manifest still has `name: @tanstack/devtools-vite`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->