### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/devtools-vite/package.json
+++ b/packages/devtools-vite/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tanstack/devtools-vite",
   "version": "0.7.0",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "description": "TanStack Vite plugin used to enhance the core devtools with additional functionalities",
   "author": "Tanner Linsley",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/devtools-vite/package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug reporting URL to package metadata, providing users with a direct link to submit issues and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->