### PR TITLE
docs: add bugs metadata for @tanstack/devtools-vite

### DIFF
--- a/packages/devtools-vite/package.json
+++ b/packages/devtools-vite/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-vite"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
This PR adds the missing `bugs` metadata to the `@tanstack/devtools-vite` package, as requested in the microbounty issue #1258.

- Added `bugs` URL pointing to the repository issues.

Fixes #1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with a reference to the bug reporting page, making it easier for users to report issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->