### PR TITLE
chore: add bugs.url metadata to all published packages

### DIFF
--- a/packages/angular-devtools/package.json
+++ b/packages/angular-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/angular-devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools-a11y/package.json
+++ b/packages/devtools-a11y/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-a11y"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools-client/package.json
+++ b/packages/devtools-client/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-client"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-ui"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-utils"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools-vite/package.json
+++ b/packages/devtools-vite/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-vite"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/event-bus-client/package.json
+++ b/packages/event-bus-client/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-event-client"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/devtools-event-bus"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/preact-devtools/package.json
+++ b/packages/preact-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/preact-devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/react-devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/solid-devtools/package.json
+++ b/packages/solid-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/solid-devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/vue-devtools/package.json
+++ b/packages/vue-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/vue-devtools"
   },
   "homepage": "https://tanstack.com/devtools",
+  "bugs": {
+    "url": "https://github.com/TanStack/devtools/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
## What

Adds the `bugs` field to every publishable package under `packages/`, pointing at the GitHub issue tracker:

```json
"bugs": {
  "url": "https://github.com/TanStack/devtools/issues"
}
```

## Why

While auditing package metadata, `bugs` was the **only** standard npm/TanStack metadata field missing across the packages. Everything else (`repository` with `directory`, `license: MIT`, `homepage`, `funding`, `author`, `keywords`) was already present and consistent. Adding `bugs.url` gives npm/registry UIs a proper "report issues" link for each package.

## Scope

All 13 publishable packages:

- `@tanstack/devtools`
- `@tanstack/devtools-client`
- `@tanstack/devtools-ui`
- `@tanstack/devtools-utils`
- `@tanstack/devtools-vite`
- `@tanstack/devtools-a11y`
- `@tanstack/devtools-event-bus`
- `@tanstack/devtools-event-client`
- `@tanstack/angular-devtools`
- `@tanstack/preact-devtools`
- `@tanstack/react-devtools`
- `@tanstack/solid-devtools`
- `@tanstack/vue-devtools`

Private packages (root, `examples/*`) were intentionally left untouched — they're never published.

## Notes

- No changeset included since this is non-functional package metadata; the new field will ride along with each package's next release. Happy to add changesets if a version bump per package is preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug reporting metadata to all packages, providing users with a centralized location to report and track issues on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->