### PR TITLE
fix(examples): align @tanstack/devtools-a11y version to fix sherif CI

### DIFF
--- a/examples/angular/a11y-devtools/package.json
+++ b/examples/angular/a11y-devtools/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
     "@tanstack/angular-devtools": "^0.0.6",
-    "@tanstack/devtools-a11y": "^0.1.4",
+    "@tanstack/devtools-a11y": "^0.1.5",
     "@tanstack/devtools-event-client": "0.4.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
         specifier: ^0.0.6
         version: link:../../../packages/angular-devtools
       '@tanstack/devtools-a11y':
-        specifier: ^0.1.4
+        specifier: ^0.1.5
         version: link:../../../packages/devtools-a11y
       '@tanstack/devtools-event-client':
         specifier: 0.4.4


### PR DESCRIPTION
## Problem

CI on `main` is failing at the `test:sherif` step:

```
⨯ error Dependency @tanstack/devtools-a11y has multiple versions defined in the workspace. multiple-dependency-versions
    examples/react/a11y-devtools     ^0.1.5  ↑ highest
    examples/angular/a11y-devtools    ^0.1.4  ↓ lowest
```

The Version Packages release bumped the **react** a11y example to `^0.1.5` but left the **angular** example at `^0.1.4`, so sherif's `multiple-dependency-versions` rule fails.

## Fix

Bump `@tanstack/devtools-a11y` to `^0.1.5` in the angular a11y example (and the matching lockfile specifier) so both examples use the same version.

`sherif` now passes locally:

```
✓ No issues found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated accessibility devtools dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->