### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/examples/angular/a11y-devtools/package.json
+++ b/examples/angular/a11y-devtools/package.json
@@ -9,7 +9,7 @@
     "test": "ng test"
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.0",
     "@angular/compiler": "^21.2.0",

--- a/examples/angular/basic/package.json
+++ b/examples/angular/basic/package.json
@@ -9,7 +9,7 @@
     "test": "ng test"
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.0",
     "@angular/compiler": "^21.2.0",

--- a/examples/angular/panel/package.json
+++ b/examples/angular/panel/package.json
@@ -9,7 +9,7 @@
     "test": "ng test"
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.0",
     "@angular/compiler": "^21.2.0",

--- a/examples/angular/with-devtools/package.json
+++ b/examples/angular/with-devtools/package.json
@@ -9,7 +9,7 @@
     "test": "ng test"
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.0",
     "@angular/compiler": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/devtools.git"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,16 @@
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 1
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
+
+trustPolicyExclude:
+  - 'chokidar@4.0.3' # Socket score 99; popular and well maintained.
+  - 'semver@5.7.2' # Socket score 100; popular and well maintained.
+  - 'semver@6.3.1' # Socket score 100; popular and well maintained.
+  - 'undici-types@6.21.0' # Socket score 100; popular and well maintained.
+  - 'vite@6.4.1' # Socket score 94; popular and well maintained.
 
 packages:
   - examples/**/*


### PR DESCRIPTION
Updates pnpm metadata to 11.9.0, enables minimumReleaseAge, and records exact trust policy exclusions verified against Socket.dev.

Verification:
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check