### PR TITLE
fix(devtools-vite): preserve valid syntax when removing devtools JSX

### DIFF
--- a/.changeset/happy-clubs-wave.md
+++ b/.changeset/happy-clubs-wave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-bundler-core': patch
+---
+
+Fix devtools JSX removal logic.

--- a/packages/devtools-bundler-core/src/remove-devtools.test.ts
+++ b/packages/devtools-bundler-core/src/remove-devtools.test.ts
@@ -604,4 +604,92 @@ export function DevtoolsProvider() {
 `),
     )
   })
+
+  test('replaces removed devtools expressions with null', () => {
+    const output = removeEmptySpace(
+      removeDevtools(
+        `
+import { TanStackDevtools } from '@tanstack/react-devtools'
+
+function functionCall(value: unknown) {
+  return value
+}
+
+export function DevtoolsProvider() {
+  const devtools1 = <TanStackDevtools />
+  const devtools2 = functionCall(<TanStackDevtools />)
+  const devtools3 = true ? <TanStackDevtools /> : <>fallback</>
+  const devtools4 = {
+    devtools: <TanStackDevtools />
+  }
+  const devtools5 = (<div>
+      {<TanStackDevtools plugins={[]} />}
+  </div>)
+  return { devtools1, devtools2, devtools3, devtools4, devtools5 }
+}
+`,
+        'test.tsx',
+      )!.code,
+    )
+
+    expect(output).toBe(
+      removeEmptySpace(`
+function functionCall(value: unknown) {
+  return value
+}
+
+export function DevtoolsProvider() {
+  const devtools1 = null
+  const devtools2 = functionCall(null)
+  const devtools3 = true ? null : <>fallback</>
+  const devtools4 = {
+    devtools: null
+  }
+  const devtools5 = (<div>
+      {null}
+  </div>)
+  return { devtools1, devtools2, devtools3, devtools4, devtools5 }
+}
+`),
+    )
+  })
+
+  test('removes devtools jsx children entirely', () => {
+    const output = removeEmptySpace(
+      removeDevtools(
+        `
+import { TanStackDevtools } from '@tanstack/react-devtools'
+
+export function DevtoolsProvider() {
+  return (
+    <>
+      <div>
+        <div>before</div>
+        <TanStackDevtools />
+        <div>after</div>
+      </div>
+      <TanStackDevtools />
+    </>
+  )
+}
+`,
+        'test.tsx',
+      )!.code,
+    )
+
+    expect(output).toBe(
+      removeEmptySpace(`
+export function DevtoolsProvider() {
+  return (
+  <>
+    <div>
+      <div>before</div>
+      <div>after</div>
+    </div>
+  </>
+  )
+}
+`),
+    )
+  })
 })

--- a/packages/devtools-bundler-core/src/remove-devtools.ts
+++ b/packages/devtools-bundler-core/src/remove-devtools.ts
@@ -130,10 +130,17 @@ export function removeDevtools(code: string, id: string) {
 
       let end = node.end
       if (code[end] === '\n') end++
-      if (parentNode?.type === 'ParenthesizedExpression') {
-        s.overwrite(node.start, end, 'null')
-      } else {
+      /**
+       * Devtools nodes can be removed safely when nested in JSX. 
+       * In all other contexts, replace them with `null` to avoid leaving invalid syntax.
+       */
+      if (
+        parentNode?.type === 'JSXElement' ||
+        parentNode?.type === 'JSXFragment'
+      ) {
         s.remove(node.start, end)
+      } else {
+        s.overwrite(node.start, end, 'null')
       }
     })
 

--- a/packages/devtools-bundler-core/src/remove-devtools.ts
+++ b/packages/devtools-bundler-core/src/remove-devtools.ts
@@ -131,7 +131,7 @@ export function removeDevtools(code: string, id: string) {
       let end = node.end
       if (code[end] === '\n') end++
       /**
-       * Devtools nodes can be removed safely when nested in JSX. 
+       * Devtools nodes can be removed safely when nested in JSX.
        * In all other contexts, replace them with `null` to avoid leaving invalid syntax.
        */
       if (


### PR DESCRIPTION
## 🎯 Changes
Fixes #457
### Issue Summary

- Devtools JSX (`<TanStackDevtools />`) was being `fully removed` without taking into account the context in which it was being used.
- This could lead to invalid syntax being left behind, which would break builds.
- Below is the example of bug:

```ts
// before removal
const devtools = <TanStackDevtools />

// after removal (broken)
const devtools =
```
### Fix

- Devtools JSX nodes are now only `fully removed` when their parent is a `JSXElement` or `JSXFragment`.
- In every other context, the node is replaced with `null` instead, which is always valid as an expression.
- New changes preserve existing behavior and fix the above issue.
- All the existing testcases pass and I have also added testcases for the new behavior.
- Below are some examples of the new behavior:

```ts
// before removal:
const devtools0 = <div><TanStackDevtools /></div>
const devtools1 = <TanStackDevtools />
const devtools2 = functionCall(<TanStackDevtools />)
const devtools3 = true ? <TanStackDevtools /> : <>fallback</>
const devtools4 = {
  devtools: <TanStackDevtools />
}
const devtools5 = (<div>
    {<TanStackDevtools plugins={[]} />}
</div>)

// after removal:
const devtools0 = <div></div>
const devtools1 = null
const devtools2 = functionCall(null)
const devtools3 = true ? null : <>fallback</>
const devtools4 = {
  devtools: null
}
const devtools5 = (<div>
    {null}
</div>)
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed devtools JSX/TSX removal to keep resulting code valid.
  * Replaced devtools expressions with `null` where needed (e.g., assignments, function arguments, conditionals, object properties, and nested expressions).
  * Preserved surrounding JSX content when removing devtools elements.

* **Release**
  * Recorded a patch release for the devtools bundler package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->