### PR TITLE
feat(devtools): add floating/draggable trigger with throw physics

### DIFF
--- a/.changeset/floating-draggable-trigger.md
+++ b/.changeset/floating-draggable-trigger.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/devtools': minor
+---
+
+Add a floating trigger mode. Set `triggerMode: 'floating'` (or choose it under
+Settings → Trigger Mode) to drag the devtools trigger anywhere on screen with
+the left mouse button. Releasing a drag with velocity throws it — it glides with
+momentum and springs back off the screen edges. The trigger is always kept
+within a padded, on-screen area (it can never end up off-screen) and its
+position is persisted to local storage.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,10 +29,16 @@ The `config` object is mainly focused around user interaction with the devtools 
 { hideUntilHover: boolean }
 ```
 
-- `position` - The position of the TanStack devtools trigger
+- `position` - The position of the TanStack devtools trigger (used when `triggerMode` is `'fixed'`)
 
 ```ts
 { position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'middle-left' | 'middle-right' }
+```
+
+- `triggerMode` - How the trigger is placed. `'fixed'` anchors it to `position`; `'floating'` lets you drag the trigger anywhere on screen (and throw it — it glides with momentum and springs back off the edges). The floating spot is persisted in local storage.
+
+```ts
+{ triggerMode: 'fixed' | 'floating' }
 ```
 
 - `panelLocation` - The location of the devtools panel

--- a/packages/devtools/src/components/trigger.test.tsx
+++ b/packages/devtools/src/components/trigger.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { DevtoolsProvider } from '../context/devtools-context'
-import { Trigger } from './trigger'
+import { Trigger, clamp, stepAxis } from './trigger'
 import type { TanStackDevtoolsConfig } from '../context/devtools-context'
 
 const renderTrigger = (config?: Partial<TanStackDevtoolsConfig>) => {
@@ -36,5 +36,53 @@ describe('Trigger', () => {
     const { queryByLabelText } = renderTrigger({ triggerHidden: true })
 
     expect(queryByLabelText('Open TanStack Devtools')).not.toBeInTheDocument()
+  })
+
+  it('renders the floating trigger without a fixed position class', () => {
+    const { queryByLabelText } = renderTrigger({ triggerMode: 'floating' })
+
+    const button = queryByLabelText('Open TanStack Devtools')
+    expect(button).toBeInTheDocument()
+  })
+})
+
+describe('throw physics', () => {
+  it('clamps values into range', () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+    expect(clamp(-5, 0, 10)).toBe(0)
+    expect(clamp(50, 0, 10)).toBe(10)
+    // Degenerate range (window smaller than trigger + padding): stays at min.
+    expect(clamp(5, 10, 0)).toBe(10)
+  })
+
+  it('advances position by velocity while inside the walls', () => {
+    const { pos, vel } = stepAxis(100, 10, 0, 500)
+    expect(pos).toBe(110)
+    expect(vel).toBeCloseTo(9.5) // 10 * FRICTION(0.95)
+  })
+
+  it('bounces and damps velocity at a wall', () => {
+    const hitMax = stepAxis(495, 20, 0, 500)
+    expect(hitMax.pos).toBe(500)
+    expect(hitMax.vel).toBeLessThan(0) // reversed
+    // 20 * 0.95 = 19, reversed & damped by RESTITUTION(0.5) => -9.5
+    expect(hitMax.vel).toBeCloseTo(-9.5)
+
+    const hitMin = stepAxis(5, -20, 0, 500)
+    expect(hitMin.pos).toBe(0)
+    expect(hitMin.vel).toBeGreaterThan(0)
+  })
+
+  it('a throw decays to a stop (loop terminates within bounds)', () => {
+    let pos = 250
+    let vel = 40
+    let frames = 0
+    while (Math.abs(vel) > 0.1 && frames < 10000) {
+      ;({ pos, vel } = stepAxis(pos, vel, 0, 500))
+      frames++
+    }
+    expect(frames).toBeLessThan(10000)
+    expect(pos).toBeGreaterThanOrEqual(0)
+    expect(pos).toBeLessThanOrEqual(500)
   })
 })

--- a/packages/devtools/src/components/trigger.tsx
+++ b/packages/devtools/src/components/trigger.tsx
@@ -1,24 +1,261 @@
-import { Show, createEffect, createMemo, createSignal } from 'solid-js'
+import {
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  untrack,
+} from 'solid-js'
 import clsx from 'clsx'
 import { createDevtoolsSettings } from '../context/use-devtools-context'
 import { createStyles } from '../styles/use-styles'
 import TanStackLogo from './tanstack-logo.png'
+import type { TriggerCoords } from '../context/devtools-store'
 import type { Accessor } from 'solid-js'
+
+// --- Throw physics (pure, unit-tested in trigger.test.tsx) ---
+const FRICTION = 0.95 // velocity retained each frame
+const RESTITUTION = 0.5 // velocity retained after a wall bounce
+const MIN_SPEED = 0.1 // px/frame below which the throw stops
+const DRAG_THRESHOLD = 4 // px of movement before a press counts as a drag
+const PADDING_RATIO = 0.5 // matches size[2] = --tsrd-font-size * 0.5
+
+export const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value))
+
+/**
+ * Advance one axis by its velocity for a single frame, bouncing off the
+ * [min, max] walls with damping. Returns the new position and velocity.
+ */
+export const stepAxis = (
+  pos: number,
+  vel: number,
+  min: number,
+  max: number,
+): { pos: number; vel: number } => {
+  let p = pos + vel
+  let v = vel * FRICTION
+  if (p <= min) {
+    p = min
+    v = -v * RESTITUTION
+  } else if (p >= max) {
+    p = max
+    v = -v * RESTITUTION
+  }
+  return { pos: p, vel: v }
+}
 
 export const Trigger = (props: {
   isOpen: Accessor<boolean>
   setIsOpen: (isOpen: boolean) => void
 }) => {
-  const { settings } = createDevtoolsSettings()
+  const { settings, setSettings } = createDevtoolsSettings()
   const [containerRef, setContainerRef] = createSignal<HTMLElement>()
+  const [buttonRef, setButtonRef] = createSignal<HTMLButtonElement>()
+  const [coords, setCoords] = createSignal<TriggerCoords | null>(
+    settings().triggerCoords ?? null,
+  )
   const styles = createStyles()
+
+  const isFloating = createMemo(() => settings().triggerMode === 'floating')
+
   const buttonStyle = createMemo(() => {
     return clsx(
       styles().mainCloseBtn,
-      styles().mainCloseBtnPosition(settings().position),
+      // Keep the fixed-position class until floating coords are seeded, so the
+      // seed reads the trigger's real on-screen spot (not the unpositioned
+      // static-flow position) and the hand-off to inline left/top is seamless.
+      (!isFloating() || !coords()) &&
+        styles().mainCloseBtnPosition(settings().position),
       styles().mainCloseBtnAnimation(props.isOpen(), settings().hideUntilHover),
+      isFloating() && styles().mainCloseBtnFloating,
     )
   })
+
+  // Padding away from the edges, matching the fixed trigger's offset (size[2]).
+  const edgePadding = (el: HTMLElement) => {
+    const fontSize = parseFloat(
+      getComputedStyle(el).getPropertyValue('--tsrd-font-size'),
+    )
+    return (Number.isFinite(fontSize) ? fontSize : 16) * PADDING_RATIO
+  }
+
+  const bounds = (el: HTMLElement) => {
+    const pad = edgePadding(el)
+    const rect = el.getBoundingClientRect()
+    return {
+      minX: pad,
+      minY: pad,
+      maxX: window.innerWidth - rect.width - pad,
+      maxY: window.innerHeight - rect.height - pad,
+    }
+  }
+
+  // --- drag state (non-reactive; only `coords` drives rendering) ---
+  let dragging = false
+  let moved = false
+  let startX = 0
+  let startY = 0
+  let startPosX = 0
+  let startPosY = 0
+  let lastX = 0
+  let lastY = 0
+  let lastT = 0
+  let vx = 0
+  let vy = 0
+  let raf: number | undefined
+
+  const cancelThrow = () => {
+    if (raf !== undefined) {
+      cancelAnimationFrame(raf)
+      raf = undefined
+    }
+  }
+
+  const persist = () => setSettings({ triggerCoords: coords() ?? undefined })
+
+  const startThrow = () => {
+    cancelThrow()
+    const tick = () => {
+      const el = buttonRef()
+      const current = coords()
+      if (!el || !current) {
+        raf = undefined
+        return
+      }
+      const b = bounds(el)
+      const nx = stepAxis(current.x, vx, b.minX, b.maxX)
+      const ny = stepAxis(current.y, vy, b.minY, b.maxY)
+      vx = nx.vel
+      vy = ny.vel
+      setCoords({ x: nx.pos, y: ny.pos })
+      if (Math.hypot(vx, vy) > MIN_SPEED) {
+        raf = requestAnimationFrame(tick)
+      } else {
+        raf = undefined
+        persist()
+      }
+    }
+    raf = requestAnimationFrame(tick)
+  }
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (!isFloating() || e.button !== 0) return
+    const el = buttonRef()
+    const current = coords()
+    if (!el || !current) return
+    cancelThrow()
+    dragging = true
+    moved = false
+    el.setPointerCapture(e.pointerId)
+    startX = e.clientX
+    startY = e.clientY
+    startPosX = current.x
+    startPosY = current.y
+    lastX = e.clientX
+    lastY = e.clientY
+    lastT = e.timeStamp
+    vx = 0
+    vy = 0
+    e.preventDefault()
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!dragging) return
+    const el = buttonRef()
+    if (!el) return
+    const dx = e.clientX - startX
+    const dy = e.clientY - startY
+    if (Math.hypot(dx, dy) > DRAG_THRESHOLD) moved = true
+    const b = bounds(el)
+    setCoords({
+      x: clamp(startPosX + dx, b.minX, b.maxX),
+      y: clamp(startPosY + dy, b.minY, b.maxY),
+    })
+    // Velocity in px per ~16ms frame, so it plugs straight into stepAxis.
+    const dt = e.timeStamp - lastT
+    if (dt > 0) {
+      vx = ((e.clientX - lastX) / dt) * 16
+      vy = ((e.clientY - lastY) / dt) * 16
+    }
+    lastX = e.clientX
+    lastY = e.clientY
+    lastT = e.timeStamp
+  }
+
+  const endDrag = (e: PointerEvent, canThrow: boolean) => {
+    if (!dragging) return
+    dragging = false
+    const el = buttonRef()
+    if (el?.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId)
+    // If the pointer sat still before release, the last flick velocity is
+    // stale — don't launch a throw the user didn't actually make.
+    if (e.timeStamp - lastT > 50) {
+      vx = 0
+      vy = 0
+    }
+    if (canThrow && moved && Math.hypot(vx, vy) > MIN_SPEED) {
+      startThrow()
+    } else {
+      persist()
+    }
+  }
+
+  const onPointerUp = (e: PointerEvent) => endDrag(e, true)
+  // A cancelled pointer (OS gesture, context menu) just drops in place.
+  const onPointerCancel = (e: PointerEvent) => endDrag(e, false)
+
+  const onClick = () => {
+    // A drag release also fires a click — swallow it so dragging never toggles.
+    if (moved) {
+      moved = false
+      return
+    }
+    props.setIsOpen(!props.isOpen())
+  }
+
+  // On going floating: seed coords from the button's current (fixed) position
+  // if there's no stored spot, otherwise clamp the restored spot into view
+  // (a saved position from a larger window must not load off-screen).
+  // Reads/writes coords untracked so this only runs on mode/ref changes.
+  createEffect(() => {
+    if (!isFloating()) return
+    const el = buttonRef()
+    if (!el) return
+    untrack(() => {
+      const current = coords()
+      if (!current) {
+        const rect = el.getBoundingClientRect()
+        setCoords({ x: rect.left, y: rect.top })
+        return
+      }
+      const b = bounds(el)
+      setCoords({
+        x: clamp(current.x, b.minX, b.maxX),
+        y: clamp(current.y, b.minY, b.maxY),
+      })
+    })
+  })
+
+  // Keep the trigger on screen when the window is resized.
+  createEffect(() => {
+    if (!isFloating()) return
+    const onResize = () => {
+      const el = buttonRef()
+      const current = coords()
+      if (!el || !current) return
+      const b = bounds(el)
+      setCoords({
+        x: clamp(current.x, b.minX, b.maxX),
+        y: clamp(current.y, b.minY, b.maxY),
+      })
+      persist()
+    }
+    window.addEventListener('resize', onResize)
+    onCleanup(() => window.removeEventListener('resize', onResize))
+  })
+
+  onCleanup(cancelThrow)
 
   createEffect(() => {
     const triggerComponent = settings().customTrigger
@@ -33,10 +270,26 @@ export const Trigger = (props: {
   return (
     <Show when={!settings().triggerHidden}>
       <button
+        ref={setButtonRef}
         type="button"
         aria-label="Open TanStack Devtools"
         class={buttonStyle()}
-        onClick={() => props.setIsOpen(!props.isOpen())}
+        style={
+          isFloating() && coords()
+            ? {
+                left: `${coords()!.x}px`,
+                top: `${coords()!.y}px`,
+                right: 'auto',
+                bottom: 'auto',
+                transform: 'none',
+              }
+            : undefined
+        }
+        onClick={onClick}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
       >
         <Show
           when={settings().customTrigger}

--- a/packages/devtools/src/components/trigger.tsx
+++ b/packages/devtools/src/components/trigger.tsx
@@ -187,7 +187,8 @@ export const Trigger = (props: {
     if (!dragging) return
     dragging = false
     const el = buttonRef()
-    if (el?.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId)
+    if (el?.hasPointerCapture(e.pointerId))
+      el.releasePointerCapture(e.pointerId)
     // If the pointer sat still before release, the last flick velocity is
     // stale — don't launch a throw the user didn't actually make.
     if (e.timeStamp - lastT > 50) {

--- a/packages/devtools/src/context/devtools-store.ts
+++ b/packages/devtools/src/context/devtools-store.ts
@@ -21,6 +21,10 @@ type TriggerPosition =
   | 'middle-left'
   | 'middle-right'
 
+type TriggerMode = 'fixed' | 'floating'
+type TriggerCoords = { x: number; y: number }
+export type { TriggerPosition, TriggerMode, TriggerCoords }
+
 type TriggerProps = {
   theme: TanStackDevtoolsTheme
 }
@@ -38,10 +42,24 @@ export type DevtoolsStore = {
      */
     hideUntilHover: boolean
     /**
-     * The position of the trigger button
+     * The position of the trigger button (used when `triggerMode` is "fixed")
      * @default "bottom-right"
      */
     position: TriggerPosition
+
+    /**
+     * How the trigger is placed on screen.
+     * - "fixed": anchored to one of the `position` corners/edges
+     * - "floating": freely draggable, position persisted in local storage
+     * @default "fixed"
+     */
+    triggerMode: TriggerMode
+    /**
+     * The persisted top-left coordinates (in px) of the floating trigger.
+     * Only used when `triggerMode` is "floating".
+     * @default undefined
+     */
+    triggerCoords?: TriggerCoords
 
     /**
      * The location of the panel once it is open
@@ -106,6 +124,8 @@ export const initialState: DevtoolsStore = {
     defaultOpen: false,
     hideUntilHover: false,
     position: 'bottom-right',
+    triggerMode: 'fixed',
+    triggerCoords: undefined,
     panelLocation: 'bottom',
     openHotkey: ['Control', '~'],
     inspectHotkey: ['Shift', 'Alt', 'CtrlOrMeta'],

--- a/packages/devtools/src/styles/use-styles.ts
+++ b/packages/devtools/src/styles/use-styles.ts
@@ -476,6 +476,17 @@ const stylesFactory = (theme: DevtoolsStore['settings']['theme']) => {
         outline: 2px solid ${t(colors.black, colors.black)};
       }
     `,
+    mainCloseBtnFloating: css`
+      /* Floating placement is driven by inline left/top, so don't animate
+         position (would fight the drag/throw rAF loop) — only opacity. */
+      transition: opacity 0.25s ease-out;
+      cursor: grab;
+      touch-action: none;
+      user-select: none;
+      &:active {
+        cursor: grabbing;
+      }
+    `,
     mainCloseBtnPosition: (position: TanStackDevtoolsConfig['position']) => {
       const base = css`
         ${position === 'top-left' ? `top: ${size[2]}; left: ${size[2]};` : ''}

--- a/packages/devtools/src/tabs/settings-tab.tsx
+++ b/packages/devtools/src/tabs/settings-tab.tsx
@@ -161,24 +161,36 @@ export const SettingsTab = () => {
           Adjust the position of the trigger button and devtools panel.
         </SectionDescription>
         <div class={styles().settingsGroup}>
+          <Select
+            label="Trigger Mode"
+            description="Fixed anchors the trigger to a corner; Floating lets you drag it anywhere (and throw it)"
+            value={settings().triggerMode}
+            options={[
+              { label: 'Fixed', value: 'fixed' },
+              { label: 'Floating', value: 'floating' },
+            ]}
+            onChange={(value) => setSettings({ triggerMode: value })}
+          />
           <div class={styles().settingRow}>
-            <Select
-              label="Trigger Position"
-              options={[
-                { label: 'Bottom Right', value: 'bottom-right' },
-                { label: 'Bottom Left', value: 'bottom-left' },
-                { label: 'Top Right', value: 'top-right' },
-                { label: 'Top Left', value: 'top-left' },
-                { label: 'Middle Right', value: 'middle-right' },
-                { label: 'Middle Left', value: 'middle-left' },
-              ]}
-              value={settings().position}
-              onChange={(value) =>
-                setSettings({
-                  position: value,
-                })
-              }
-            />
+            <Show when={settings().triggerMode === 'fixed'}>
+              <Select
+                label="Trigger Position"
+                options={[
+                  { label: 'Bottom Right', value: 'bottom-right' },
+                  { label: 'Bottom Left', value: 'bottom-left' },
+                  { label: 'Top Right', value: 'top-right' },
+                  { label: 'Top Left', value: 'top-left' },
+                  { label: 'Middle Right', value: 'middle-right' },
+                  { label: 'Middle Left', value: 'middle-left' },
+                ]}
+                value={settings().position}
+                onChange={(value) =>
+                  setSettings({
+                    position: value,
+                  })
+                }
+              />
+            </Show>
             <Select
               label="Panel Position"
               value={settings().panelLocation}


### PR DESCRIPTION
## 🎯 Changes

Adds a **floating trigger mode** so the devtools trigger no longer has to stay pinned to one of the eight fixed corners.

- New setting `triggerMode: 'fixed' | 'floating'` (default `fixed`), configurable in **Settings → Trigger Mode**. Fixed keeps the existing 8-position behavior; Floating hides the position dropdown and makes the trigger draggable.
- **Drag** the trigger anywhere with the left mouse button (pointer events, so touch works too). A move past a small threshold is treated as a drag and never toggles the panel.
- **Throw physics**: releasing a drag with velocity glides the trigger with friction decay and springs back off the screen edges (free placement + wall bounce).
- **Never off-screen**: the movable area is padded from the edges by the same offset the fixed trigger uses (`size[2]` = `--tsrd-font-size × 0.5`). Position is re-clamped on window `resize` and on load, so a spot saved in a larger window can't load off-screen.
- Position is **persisted to local storage** (`triggerCoords`) via the existing settings store.
- `clamp` / `stepAxis` physics are pure functions with unit tests; docs updated in `configuration.md` (the reference interface page is autogenerated from the type comments).

Verified live in the React basic example (drag follows the pointer, flick glides + bounces, hard fling stays in-bounds, position persists across reload).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset (`@tanstack/devtools` minor).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a floating trigger mode for the devtools button.
  - Drag the trigger anywhere within the screen; it glides with momentum, bounces off edges, and remembers its position.
  - Added a Settings option to switch between fixed and floating trigger modes.
  - Fixed positioning controls are shown only when fixed mode is selected.

- **Documentation**
  - Updated configuration guidance with floating mode and trigger positioning details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->