### PR TITLE
docs: add README header banners to the framework adapter packages

### DIFF
--- a/packages/preact-devtools/README.md
+++ b/packages/preact-devtools/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=preact&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=preact"
+    />
+    <img
+      src="https://tanstack.com/api/readme/devtools.png?framework=preact"
+      alt="TanStack Preact Devtools"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/preact-devtools
 
 This package is still under active development and might have breaking changes in the future. Please use it with caution.

--- a/packages/react-devtools/README.md
+++ b/packages/react-devtools/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=react&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=react"
+    />
+    <img
+      src="https://tanstack.com/api/readme/devtools.png?framework=react"
+      alt="TanStack React Devtools"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/react-devtools
 
 This package is still under active development and might have breaking changes in the future. Please use it with caution.

--- a/packages/solid-devtools/README.md
+++ b/packages/solid-devtools/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=solid&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=solid"
+    />
+    <img
+      src="https://tanstack.com/api/readme/devtools.png?framework=solid"
+      alt="TanStack Solid Devtools"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/solid-devtools
 
 This package is still under active development and might have breaking changes in the future. Please use it with caution.

--- a/packages/vue-devtools/README.md
+++ b/packages/vue-devtools/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=vue&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/devtools.png?framework=vue"
+    />
+    <img
+      src="https://tanstack.com/api/readme/devtools.png?framework=vue"
+      alt="TanStack Vue Devtools"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/vue-devtools
 
 This package is still under active development and might have breaking changes in the future. Please use it with caution.


### PR DESCRIPTION
Follow-up to #490, which is already merged.

That PR swapped the README banners that **already existed** for the
`/api/readme/` endpoint. It did not add banners to packages that never had
one, which left an inconsistency: sibling framework adapters in this repo now
look different from each other purely because of which PNG happened to be
committed before.

This adds the banner to the public framework adapter packages that were
missed: `@tanstack/react-devtools`, `@tanstack/preact-devtools`, `@tanstack/solid-devtools`, `@tanstack/vue-devtools`.

## Scope

Only packages a user installs directly. Internal packages are deliberately
left banner-free - a branded header on plumbing nobody browses is noise:

- build/tooling packages (vite, rspack and cli plugins)
- `*-core` packages and internal client/server split packages
- storage and persistence backends

## Verification

Every URL added here was requested against the live endpoint and returned
`200 image/png` at 1800x450. Light and dark are served through `<picture>`,
with the trailing `<img>` left as the light variant so renderers that ignore
`<picture>` (npm, most editors) still show a banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added responsive, centered banners to the Preact, React, Solid, and Vue Devtools README files.
  * Banners automatically adapt to light and dark themes.
  * Included descriptive metadata for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->