### PR TITLE
chore(devtools): bump launch-editor and picomatch to fix security advisories

### DIFF
--- a/.changeset/olive-experts-look.md
+++ b/.changeset/olive-experts-look.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-bundler-core': patch
+---
+
+chore: bump launch-editor to ^2.14.1 and picomatch to ^4.0.5 to resolve security advisories in shell-quote (GHSA-w7jw-789q-3m8p, GHSA-395f-4hp3-45gv) and picomatch (GHSA-c2c7-rcm5-vvqj, GHSA-3v7f-55p6-f55p)

--- a/.changeset/olive-experts-look.md
+++ b/.changeset/olive-experts-look.md
@@ -3,3 +3,5 @@
 ---
 
 chore: bump launch-editor to ^2.14.1 and picomatch to ^4.0.5 to resolve security advisories in shell-quote (GHSA-w7jw-789q-3m8p, GHSA-395f-4hp3-45gv) and picomatch (GHSA-c2c7-rcm5-vvqj, GHSA-3v7f-55p6-f55p)
+
+This only covers the `@tanstack/devtools-bundler-core` dependency path — its `launch-editor` dependency now resolves the patched `shell-quote@1.10.0`, and `picomatch` resolves `4.0.5`. A vulnerable `shell-quote@1.8.3` remains in the lockfile via `launch-editor@2.13.2`, pulled in by `@rspack/dev-server` in the `react-rspack-example` app's devDependencies; it is development-only and does not affect any published package.

--- a/packages/devtools-bundler-core/package.json
+++ b/packages/devtools-bundler-core/package.json
@@ -54,10 +54,10 @@
     "@tanstack/devtools-client": "workspace:*",
     "@tanstack/devtools-event-bus": "workspace:*",
     "chalk": "^5.6.2",
-    "launch-editor": "^2.11.1",
+    "launch-editor": "^2.14.1",
     "magic-string": "^0.30.0",
     "oxc-parser": "^0.120.0",
-    "picomatch": "^4.0.3"
+    "picomatch": "^4.0.5"
   },
   "devDependencies": {
     "@types/picomatch": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1607,8 +1607,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       launch-editor:
-        specifier: ^2.11.1
-        version: 2.13.2
+        specifier: ^2.14.1
+        version: 2.14.1
       magic-string:
         specifier: ^0.30.0
         version: 0.30.21
@@ -1616,8 +1616,8 @@ importers:
         specifier: ^0.120.0
         version: 0.120.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       picomatch:
-        specifier: ^4.0.3
-        version: 4.0.4
+        specifier: ^4.0.5
+        version: 4.0.5
     devDependencies:
       '@types/picomatch':
         specifier: ^4.0.2
@@ -9057,6 +9057,9 @@ packages:
   launch-editor@2.13.2:
     resolution: {integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==}
 
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
+
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
@@ -10232,6 +10235,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -10820,6 +10827,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
@@ -19870,6 +19881,11 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.10.0
+
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
@@ -21579,6 +21595,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
@@ -22325,6 +22343,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.10.0: {}
 
   shell-quote@1.8.3: {}
 


### PR DESCRIPTION
## 🎯 Changes

Bumps two dependencies in `@tanstack/devtools-bundler-core` to pull in fixes for four security advisories:

- `launch-editor`: `^2.11.1` -> `^2.14.1` - updates its transitive `shell-quote` dependency from `1.8.3` to `1.10.0`, fixing:
  - [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p)
  - [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv)
- `picomatch`: `^4.0.3` -> `^4.0.5`, fixing:
  - [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj)
  - [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p)

No source code changes, dependency bumps only, both within their current major versions.

Note: a `shell-quote@1.8.3` entry remains in the lockfile, but it is only reachable through `@rspack/dev-server` in the `react-rspack-example` app's devDependencies, it does not affect any published package.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bundled dependencies to address reported security advisories.
  * Improved security and maintenance through updated dependency versions.

* **Chores**
  * Scheduled a patch release for the developer tools bundler package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->