### PR TITLE
fix(event-bus): respect explicit connection config

### DIFF
--- a/.changeset/calm-buses-connect.md
+++ b/.changeset/calm-buses-connect.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools-event-bus': patch
+---
+
+Honor explicit client connection options when bundlers inject event bus defaults.

--- a/packages/event-bus/src/client/client.ts
+++ b/packages/event-bus/src/client/client.ts
@@ -89,18 +89,18 @@ export class ClientEventBus {
     this.#eventTarget.dispatchEvent(new CustomEvent('tanstack-connect-success'))
   }
   constructor({
-    port = 4206,
-    host = 'localhost',
-    protocol = 'http',
+    port = getDefaultPort(4206),
+    host = getDefaultHost('localhost'),
+    protocol = getDefaultProtocol('http'),
     debug = false,
     connectToServerBus = false,
   }: ClientEventBusConfig = {}) {
     this.#debug = debug
     this.#broadcastChannel = new BroadcastChannel('tanstack-devtools')
     this.#eventSource = null
-    this.#port = getDefaultPort(port)
-    this.#host = getDefaultHost(host)
-    this.#protocol = getDefaultProtocol(protocol)
+    this.#port = port
+    this.#host = host
+    this.#protocol = protocol
     this.#socket = null
     this.#connectToServerBus = connectToServerBus
     this.#eventTarget = this.getGlobalTarget()

--- a/packages/event-bus/tests/client.test.ts
+++ b/packages/event-bus/tests/client.test.ts
@@ -101,6 +101,33 @@ describe('ClientEventBus', () => {
       expect(mockEventSourceInstances.length).toBe(0)
       bus.stop()
     })
+
+    it('should prefer explicit config over bundler-injected defaults', () => {
+      Object.assign(globalThis, {
+        __TANSTACK_DEVTOOLS_PORT__: 4206,
+        __TANSTACK_DEVTOOLS_HOST__: 'localhost',
+        __TANSTACK_DEVTOOLS_PROTOCOL__: 'http',
+      })
+
+      try {
+        const bus = new ClientEventBus({
+          connectToServerBus: true,
+          port: 443,
+          host: 'devtools.example.com',
+          protocol: 'https',
+        })
+        bus.start()
+
+        expect(mockWebSocketInstances[0].url).toBe(
+          'wss://devtools.example.com:443/__devtools/ws',
+        )
+        bus.stop()
+      } finally {
+        Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_PORT__')
+        Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_HOST__')
+        Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_PROTOCOL__')
+      }
+    })
   })
 
   describe('connectWebSocket with protocol', () => {

--- a/packages/event-bus/tests/client.test.ts
+++ b/packages/event-bus/tests/client.test.ts
@@ -109,8 +109,9 @@ describe('ClientEventBus', () => {
         __TANSTACK_DEVTOOLS_PROTOCOL__: 'http',
       })
 
+      let bus: ClientEventBus | undefined
       try {
-        const bus = new ClientEventBus({
+        bus = new ClientEventBus({
           connectToServerBus: true,
           port: 443,
           host: 'devtools.example.com',
@@ -121,8 +122,8 @@ describe('ClientEventBus', () => {
         expect(mockWebSocketInstances[0].url).toBe(
           'wss://devtools.example.com:443/__devtools/ws',
         )
-        bus.stop()
       } finally {
+        bus?.stop()
         Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_PORT__')
         Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_HOST__')
         Reflect.deleteProperty(globalThis, '__TANSTACK_DEVTOOLS_PROTOCOL__')


### PR DESCRIPTION
## 🎯 Changes

- Fixes #499.
- Ensures explicit ClientEventBus connection options take precedence over bundler-injected defaults.
- Preserves injected values as defaults when explicit options are omitted.
- Adds regression coverage for explicit host, port, and protocol configuration.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit event bus connection settings now take precedence over automatically injected defaults.
  * Improved handling of custom host, port, and protocol values, including secure WebSocket connections.

* **Tests**
  * Added coverage verifying that explicit connection options are honored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->