### PR TITLE
fix(devtools-utils): align Svelte factory contracts

### DIFF
--- a/.changeset/fresh-svelte-factories.md
+++ b/.changeset/fresh-svelte-factories.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/devtools-utils': minor
+'@tanstack/svelte-devtools': patch
+---
+
+Align Svelte panel construction and plugin metadata with the other framework factories, register panel cleanup with the Svelte lifecycle, and forward shared plugin props through the Svelte adapter.

--- a/.changeset/fresh-svelte-factories.md
+++ b/.changeset/fresh-svelte-factories.md
@@ -3,4 +3,4 @@
 '@tanstack/svelte-devtools': patch
 ---
 
-Align Svelte panel construction and plugin metadata with the other framework factories, register panel cleanup with the Svelte lifecycle, and forward shared plugin props through the Svelte adapter.
+Align Svelte panel construction and plugin metadata with the other framework factories, forward shared plugin props through the Svelte adapter, and cleanly replace mounted components when plugin props change.

--- a/.changeset/fresh-svelte-factories.md
+++ b/.changeset/fresh-svelte-factories.md
@@ -3,4 +3,4 @@
 '@tanstack/svelte-devtools': patch
 ---
 
-Align Svelte panel construction and plugin metadata with the other framework factories, forward shared plugin props through the Svelte adapter, and cleanly replace mounted components when plugin props change.
+Align Svelte panel construction and plugin metadata with the other framework factories, use compiled Svelte components to own panel and no-op lifecycles, forward shared plugin props through the Svelte adapter, and cleanly replace mounted components when plugin props change.

--- a/.changeset/fresh-svelte-factories.md
+++ b/.changeset/fresh-svelte-factories.md
@@ -3,4 +3,4 @@
 '@tanstack/svelte-devtools': patch
 ---
 
-Align Svelte panel construction and plugin metadata with the other framework factories, use compiled Svelte components to own panel and no-op lifecycles, forward shared plugin props through the Svelte adapter, and cleanly replace mounted components when plugin props change.
+Align Svelte panel construction and plugin metadata with the other framework factories, use compiled Svelte components to own panel and no-op lifecycles, forward shared plugin props through the Svelte adapter, and update mounted component props without resetting their state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,15 +190,17 @@ This client is a singleton (`devtoolsEventClient`) used by both the core shell a
 Each framework adapter is a thin wrapper that bridges its framework's component model to the core Solid.js shell. The pattern is the same across all adapters:
 
 1. **Creates a `TanStackDevtoolsCore` instance** with the user's plugins and config.
-2. **Mounts it to a DOM element** using the framework's lifecycle hooks (`useEffect` in React, `onMounted` in Vue, `onMount` in Solid).
-3. **Converts framework-specific plugin definitions** into the core's DOM-based `render(el, theme)` interface. Each adapter defines its own plugin type (e.g. `TanStackDevtoolsReactPlugin`) that accepts framework-native components, then wraps them in a `render` callback that the core calls with a target DOM element and the current theme.
-4. **Uses the framework's portal/teleport mechanism** to render plugin components into the core's DOM containers:
+2. **Mounts it to a DOM element** using the framework's lifecycle APIs, such as `useEffect` in React, `onMounted` in Vue, `$effect` in Svelte, and `onMount` in Solid.
+3. **Converts framework-specific plugin definitions** into the core's DOM-based `render(el, props)` interface. Each adapter defines its own plugin type (e.g. `TanStackDevtoolsReactPlugin`) that accepts framework-native components, then wraps them in a `render` callback that the core calls with a target DOM element and `{ theme, devtoolsOpen }`.
+4. **Uses the framework's rendering API** to render plugin components into the core's DOM containers:
    - **React** -- `createPortal()` from `react-dom`
    - **Vue** -- `<Teleport :to="'#' + plugin.id" />`
    - **Solid** -- `<Portal mount={el} />`
    - **Preact** -- Same portal pattern as React
+   - **Svelte** -- `mount(component, { target: el, props })`
+   - **Angular** -- `createComponent()` with the container's environment injector
 
-The key insight: the core shell is always Solid.js, but your plugins run in **your** framework. A React plugin is a real React component rendered by React's `createPortal` into a DOM element that the Solid.js shell created. A Vue plugin is a real Vue component rendered by Vue's `<Teleport>`. The adapters bridge this gap so you never need to think about Solid.js unless you want to.
+The key insight: the core shell is always Solid.js, but your plugins run in **your** framework. Each adapter receives the same plugin props and renders a native framework component into a DOM element created by the Solid.js shell. The adapters bridge this gap so you never need to think about Solid.js unless you want to.
 
 ### What an adapter does NOT do
 

--- a/docs/devtools-utils.md
+++ b/docs/devtools-utils.md
@@ -77,7 +77,7 @@ const [MyPlugin, NoOpPlugin] = createReactPlugin({
 
 The returned tuple contains two factory functions:
 
-- **`Plugin()`** -- returns a plugin object with `name`, `id`, `defaultOpen`, and a `render` function that renders your `Component` with the current theme.
+- **`Plugin()`** -- returns a plugin object with `name`, `id`, `defaultOpen`, and a `render` function that renders your `Component` with the current plugin props.
 - **`NoOpPlugin()`** -- returns a plugin object with the same metadata but a `render` function that renders an empty fragment. Use this for production builds where you want to strip devtools out.
 
 A common pattern for tree-shaking:
@@ -90,15 +90,15 @@ const ActivePlugin = process.env.NODE_ENV === 'development' ? MyPlugin : NoOpPlu
 
 ### createReactPanel
 
-For library authors shipping a class-based devtools core that exposes `mount(el, theme)` and `unmount()` methods. This factory wraps that class in a React component that handles mounting into a `div`, passing the theme, and cleaning up on unmount.
+For library authors shipping a class-based devtools core that exposes `mount(el, props)` and `unmount()` methods. This factory wraps that class in a React component that handles mounting into a `div`, passing the complete plugin props, and cleaning up on unmount.
 
 **Signature:**
 
 ```ts
 function createReactPanel<
-  TComponentProps extends DevtoolsPanelProps | undefined,
+  TComponentProps extends DevtoolsPanelProps,
   TCoreDevtoolsClass extends {
-    mount: (el: HTMLElement, theme: 'light' | 'dark') => void
+    mount: (el: HTMLElement, props: DevtoolsPanelProps) => void
     unmount: () => void
   },
 >(CoreClass: new () => TCoreDevtoolsClass): readonly [Panel, NoOpPanel]
@@ -107,10 +107,13 @@ function createReactPanel<
 **Usage:**
 
 ```tsx
-import { createReactPanel } from '@tanstack/devtools-utils/react'
+import {
+  createReactPanel,
+  type DevtoolsPanelProps,
+} from '@tanstack/devtools-utils/react'
 
 class MyDevtoolsCore {
-  mount(el: HTMLElement, theme: 'light' | 'dark') {
+  mount(el: HTMLElement, props: DevtoolsPanelProps) {
     // render your devtools UI into el
   }
   unmount() {
@@ -129,9 +132,9 @@ const [MyPlugin, NoOpPlugin] = createReactPlugin({
 
 The returned `Panel` component:
 - Creates a `div` with `height: 100%` and stores a ref to it.
-- Instantiates `CoreClass` on mount and calls `core.mount(el, theme)`.
+- Instantiates `CoreClass` on mount and calls `core.mount(el, props)`.
 - Calls `core.unmount()` on cleanup.
-- Re-mounts when the `theme` prop changes.
+- Re-mounts when the plugin props change.
 
 `NoOpPanel` renders an empty fragment and does nothing.
 
@@ -262,14 +265,18 @@ The panel component accepts `theme` and `devtoolsProps` as props. It mounts the 
 
 ### createSveltePlugin
 
-The Svelte factory takes a `name` string and a Svelte component as separate arguments, similar to the Vue API.
+The Svelte factory takes the plugin metadata and Svelte component in a configuration object.
 
 **Signature:**
 
 ```ts
 function createSveltePlugin<TComponentProps extends Record<string, any>>(
-  name: string,
-  component: Component<TComponentProps>,
+  config: {
+    name: string
+    id?: string
+    defaultOpen?: boolean
+    Component: Component<TComponentProps>
+  },
 ): readonly [Plugin, NoOpPlugin]
 ```
 
@@ -279,13 +286,18 @@ function createSveltePlugin<TComponentProps extends Record<string, any>>(
 import { createSveltePlugin } from '@tanstack/devtools-utils/svelte'
 import MyStorePanel from './MyStorePanel.svelte'
 
-const [MyPlugin, NoOpPlugin] = createSveltePlugin('My Store', MyStorePanel)
+const [MyPlugin, NoOpPlugin] = createSveltePlugin({
+  Component: MyStorePanel,
+  name: 'My Store',
+  id: 'my-store',
+  defaultOpen: true,
+})
 ```
 
 The returned functions:
 
-- **`Plugin(props?)`** -- returns `{ name, component, props }` where `component` is your Svelte component.
-- **`NoOpPlugin(props?)`** -- returns `{ name, component: NoOpComponent, props }` where the component renders nothing visible.
+- **`Plugin(props?)`** -- returns the plugin metadata, component, and forwarded props.
+- **`NoOpPlugin(props?)`** -- preserves the plugin metadata and props but replaces the component with one that renders nothing visible.
 
 Both accept an optional `props` object that gets forwarded to the component on mount.
 
@@ -299,7 +311,7 @@ import { createSveltePanel } from '@tanstack/devtools-utils/svelte'
 const [MyPanel, NoOpPanel] = createSveltePanel(MyDevtoolsCore)
 ```
 
-The panel accepts `theme` and `devtoolsProps` props. It creates a `div` element, mounts the core instance into it, and calls `unmount()` on cleanup.
+The panel constructs the core without arguments. It creates a `div` element, passes the complete `{ theme, devtoolsOpen }` plugin props to `mount()`, and registers `unmount()` with Svelte's component cleanup lifecycle.
 
 ## Angular
 

--- a/docs/framework/react/adapter.md
+++ b/docs/framework/react/adapter.md
@@ -28,7 +28,7 @@ Each plugin describes a tab in the devtools panel:
 ```ts
 type PluginRender =
   | JSX.Element
-  | ((el: HTMLElement, theme: 'dark' | 'light') => JSX.Element)
+  | ((el: HTMLElement, props: TanStackDevtoolsPluginProps) => JSX.Element)
 
 type TanStackDevtoolsReactPlugin = {
   id?: string
@@ -38,7 +38,7 @@ type TanStackDevtoolsReactPlugin = {
 }
 ```
 
-- **`render`** can be a JSX element (simplest -- just pass `<YourPanel />`) or a function that receives the container element and current theme. The function form is useful when you need to access the raw DOM element or respond to theme changes.
+- **`render`** can be a JSX element (simplest -- just pass `<YourPanel />`) or a function that receives the container element and current `{ theme, devtoolsOpen }` props. The function form is useful when you need to access the raw DOM element or respond to plugin state changes.
 - **`name`** works the same way -- use a string for plain text, or JSX / a function for custom tab titles.
 - **`id`** is an optional unique identifier. If omitted, it is generated from the name.
 - **`defaultOpen`** marks the plugin as initially active when no other plugins are open.

--- a/docs/framework/svelte/adapter.md
+++ b/docs/framework/svelte/adapter.md
@@ -47,6 +47,8 @@ type TanStackDevtoolsSveltePlugin = {
 
 The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. It passes `{ theme, devtoolsOpen, ...plugin.props }` to the component through Svelte's `mount()` API.
 
+When the core renders a plugin again, the adapter unmounts the component associated with that container before mounting its replacement. This runs Svelte cleanup and leaves one component instance owning the container.
+
 ```svelte
 <!-- Svelte: pass component reference + props -->
 <script lang="ts">

--- a/docs/framework/svelte/adapter.md
+++ b/docs/framework/svelte/adapter.md
@@ -38,14 +38,14 @@ type TanStackDevtoolsSveltePlugin = {
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | `string` (optional) | Unique identifier for the plugin. |
-| `component` | `Component<any>` | The Svelte component to render as the plugin panel content. |
-| `name` | `string \| Component<any>` | Display name for the tab title. Can be a plain string or a Svelte component for custom rendering. |
-| `props` | `Record<string, any>` (optional) | Additional props passed to the plugin component on mount. |
+| `component` | `Component<any>` | The Svelte component to render as the plugin panel content. It receives the shared `theme` and `devtoolsOpen` props. |
+| `name` | `string \| Component<any>` | Display name for the tab title. A custom Svelte component receives the same merged plugin props. |
+| `props` | `Record<string, any>` (optional) | Additional props merged with the shared plugin props when the component mounts. |
 | `defaultOpen` | `boolean` (optional) | Whether this plugin tab should be open by default. |
 
 ## Key Difference from Other Frameworks
 
-The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. Props are provided through the `props` field and passed to the component via Svelte's `mount()` API, rather than being embedded directly in a JSX expression.
+The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. It passes `{ theme, devtoolsOpen, ...plugin.props }` to the component through Svelte's `mount()` API.
 
 ```svelte
 <!-- Svelte: pass component reference + props -->

--- a/docs/framework/svelte/adapter.md
+++ b/docs/framework/svelte/adapter.md
@@ -47,7 +47,7 @@ type TanStackDevtoolsSveltePlugin = {
 
 The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. It passes `{ theme, devtoolsOpen, ...plugin.props }` to the component through Svelte's `mount()` API.
 
-When the core renders a plugin again, the adapter unmounts the component associated with that container before mounting its replacement. This runs Svelte cleanup and leaves one component instance owning the container.
+When the core renders a plugin again, the adapter updates the existing Svelte host with the latest component and props. If the component identity is unchanged, its state and lifecycle remain intact. The adapter unmounts the host when the plugin is destroyed or the Devtools instance shuts down.
 
 ```svelte
 <!-- Svelte: pass component reference + props -->

--- a/docs/framework/svelte/basic-setup.md
+++ b/docs/framework/svelte/basic-setup.md
@@ -48,6 +48,6 @@ Import the desired devtools and provide them to the `TanStackDevtools` component
 <TanStackDevtools {plugins} />
 ```
 
-> Note: The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. Additional props can be provided via the `props` field and are passed to the component on mount.
+> Note: The Svelte adapter uses `component` (a Svelte component reference) instead of `render` (a JSX element) in plugin definitions. Components receive the shared `theme` and `devtoolsOpen` props. Additional values from the plugin's `props` field are merged into the same object when the component mounts.
 
 Finally, add any additional configuration you desire to the `TanStackDevtools` component. More information can be found under the [TanStack Devtools Configuration](../../configuration) section.

--- a/docs/plugin-lifecycle.md
+++ b/docs/plugin-lifecycle.md
@@ -7,13 +7,20 @@ Every TanStack Devtools plugin follows a well-defined lifecycle: it is registere
 
 ## Plugin Interface
 
-All plugins implement the `TanStackDevtoolsPlugin` interface, which is the low-level contract between a plugin and the devtools core. Framework adapters (React, Vue, Solid, Preact) wrap this interface so you can work with familiar components, but under the hood every plugin is reduced to these fields:
+All plugins implement the `TanStackDevtoolsPlugin` interface, which is the low-level contract between a plugin and the devtools core. Framework adapters wrap this interface so you can work with familiar components, but under the hood every plugin is reduced to these fields:
 
 ```ts
+interface TanStackDevtoolsPluginProps {
+  theme: 'dark' | 'light'
+  devtoolsOpen: boolean
+}
+
 interface TanStackDevtoolsPlugin {
   id?: string
-  name: string | ((el: HTMLHeadingElement, theme: 'dark' | 'light') => void)
-  render: (el: HTMLDivElement, theme: 'dark' | 'light') => void
+  name:
+    | string
+    | ((el: HTMLHeadingElement, props: TanStackDevtoolsPluginProps) => void)
+  render: (el: HTMLDivElement, props: TanStackDevtoolsPluginProps) => void
   destroy?: (pluginId: string) => void
   defaultOpen?: boolean
 }
@@ -28,7 +35,7 @@ A unique identifier for the plugin. If you omit it, the core generates one from 
 Displayed as the tab title in the sidebar. This can be:
 
 - **A plain string** - rendered as text inside an `<h3>` element.
-- **A function** - receives the heading element (`HTMLHeadingElement`) and the current theme (`'dark' | 'light'`). You can render anything into the heading, such as an icon next to the name or a fully custom title.
+- **A function** - receives the heading element and the current `{ theme, devtoolsOpen }` props. You can render anything into the heading, such as an icon next to the name or a fully custom title.
 
 ```ts
 // Simple string name
@@ -36,7 +43,7 @@ Displayed as the tab title in the sidebar. This can be:
 
 // Custom title via function
 {
-  name: (el, theme) => {
+  name: (el, { theme }) => {
     el.innerHTML = `<span style="color: ${theme === 'dark' ? '#fff' : '#000'}">My Plugin</span>`
   },
   render: (el) => { /* ... */ }
@@ -45,18 +52,18 @@ Displayed as the tab title in the sidebar. This can be:
 
 ### `render` (required)
 
-The main rendering function. It receives a `<div>` container element and the current theme. Your job is to render your plugin UI into this container using whatever approach you prefer - raw DOM manipulation, a framework portal, or anything else.
+The main rendering function receives a `<div>` container element and the current `{ theme, devtoolsOpen }` props. Your job is to render your plugin UI into this container using whatever approach you prefer - raw DOM manipulation, a framework portal, or anything else.
 
 ```ts
-render: (el, theme) => {
-  el.innerHTML = `<div class="${theme}">Hello from my plugin!</div>`
+render: (el, { theme, devtoolsOpen }) => {
+  el.innerHTML = `<div class="${theme}" data-open="${devtoolsOpen}">Hello from my plugin!</div>`
 }
 ```
 
 The `render` function is called:
 
 1. When the plugin's tab is first activated (clicked or opened by default).
-2. When the theme changes, so your UI can adapt.
+2. When the theme or devtools open state changes, so your UI can adapt.
 
 ### `destroy` (optional)
 
@@ -82,13 +89,13 @@ Here is what happens when you provide plugins to the devtools:
    - A content container: `<div id="plugin-container-{pluginId}">` where the plugin renders its UI.
    - A title container: `<h3 id="plugin-title-container-{pluginId}">` where the plugin's name is rendered.
 
-3. **Title rendering** - For each plugin, the core checks if `name` is a string or function. If it's a string, the text is set directly on the heading element. If it's a function, the function is called with the heading element and current theme.
+3. **Title rendering** - For each plugin, the core checks if `name` is a string or function. If it is a string, the text is set directly on the heading element. If it is a function, the function is called with the heading element and current plugin props.
 
-4. **Plugin activation** - When the user clicks a plugin's tab (or the plugin is auto-opened via `defaultOpen`), the plugin is added to the `activePlugins` list. The core then calls `plugin.render(container, theme)` with the content `<div>` and the current theme.
+4. **Plugin activation** - When the user clicks a plugin's tab (or the plugin is auto-opened via `defaultOpen`), the plugin is added to the `activePlugins` list. The core then calls `plugin.render(container, props)` with the content `<div>` and `{ theme, devtoolsOpen }`.
 
 5. **Rendering** - The container is a regular `<div>` element. Your plugin can render anything into it - DOM nodes, a framework component tree via portals, a canvas, an iframe, etc.
 
-6. **Theme changes** - When the user toggles the theme in settings, `render` is called again with the new theme value. Your plugin should update its appearance accordingly.
+6. **Plugin prop changes** - When the theme or devtools open state changes, `render` is called again with the new props. Your plugin should update accordingly.
 
 ```mermaid
 flowchart TD
@@ -97,7 +104,7 @@ flowchart TD
     C --> D["&lt;h3 id='plugin-title-container-{id}'&gt;<br/>created per plugin"]
     C --> E["&lt;div id='plugin-container-{id}'&gt;<br/>created per active plugin"]
     D --> F["plugin.name<br/><i>string set or function called</i>"]
-    E --> G["plugin.render(div, theme)<br/><i>called with container + theme</i>"]
+    E --> G["plugin.render(div, props)<br/><i>called with container + plugin props</i>"]
 ```
 
 ## Framework Adapter Pattern
@@ -167,6 +174,30 @@ The Vue adapter uses `<Teleport>` to render your Vue component into the containe
 
 Your Vue component receives the `theme` as a prop along with any other props you pass. It runs within the Vue app's reactivity system with full access to composition API, inject/provide, etc.
 
+### Svelte
+
+The Svelte adapter mounts the plugin component directly into the container and forwards the shared plugin props together with any plugin-specific props:
+
+```svelte
+<!-- What you write: -->
+<script lang="ts">
+  import { TanStackDevtools } from '@tanstack/svelte-devtools'
+  import MyPluginComponent from './MyPluginComponent.svelte'
+
+  const plugins = [
+    {
+      name: 'My Plugin',
+      component: MyPluginComponent,
+      props: { someProp: 'value' },
+    },
+  ]
+</script>
+
+<TanStackDevtools {plugins} />
+```
+
+Internally, the adapter calls `mount(component, { target, props })` with `{ theme, devtoolsOpen, ...plugin.props }`. It calls `unmount()` when the plugin is destroyed, which runs the component's Svelte cleanup lifecycle.
+
 ### The Key Insight
 
 ```mermaid
@@ -177,14 +208,15 @@ graph LR
     subgraph core["Devtools Core (Solid.js)"]
         container["Plugin Container<br/>&lt;div id='plugin-container-{id}'&gt;"]
     end
-    comp -- "Portal / Teleport" --> container
+    comp -- "Framework rendering API" --> container
 ```
 
-Regardless of framework, your plugin component runs in its **normal framework context** with full reactivity, hooks, signals, lifecycle methods, and dependency injection. It just renders into a different DOM location via portals or teleports. This means:
+Regardless of framework, your plugin component runs in its **normal framework context** with full reactivity, hooks, signals, lifecycle methods, and dependency injection. The adapter renders it into a DOM location owned by the devtools core. This means:
 
 - React plugins can use `useState`, `useEffect`, `useContext`, and any React library.
 - Solid plugins can use signals, stores, `createEffect`, and the full Solid API.
 - Vue plugins can use `ref`, `computed`, `watch`, `inject`, and any Vue composable.
+- Svelte plugins can use runes, context, lifecycle hooks, and any Svelte library.
 
 The framework adapter handles all the wiring between your component and the devtools container.
 
@@ -212,5 +244,6 @@ Framework adapters handle their own cleanup automatically:
 - **React** unmounts the portal, which triggers the normal React cleanup cycle (`useEffect` cleanup functions, etc.).
 - **Vue** destroys the Teleport, which runs `onUnmounted` hooks in your component.
 - **Solid** disposes of the Portal's reactive scope, running any `onCleanup` callbacks.
+- **Svelte** calls `unmount()` for the mounted component, running its cleanup lifecycle.
 
 You typically do **not** need to implement `destroy` unless your plugin has manual subscriptions, timers, WebSocket connections, or other resources that aren't tied to your framework's lifecycle. If all your cleanup is handled by framework hooks (like `useEffect` cleanup in React or `onCleanup` in Solid), the adapter takes care of it for you.

--- a/docs/plugin-lifecycle.md
+++ b/docs/plugin-lifecycle.md
@@ -196,7 +196,7 @@ The Svelte adapter mounts the plugin component directly into the container and f
 <TanStackDevtools {plugins} />
 ```
 
-Internally, the adapter calls `mount(component, { target, props })` with `{ theme, devtoolsOpen, ...plugin.props }`. Before a repeated render, it unmounts the component associated with that container and then mounts the replacement. It also unmounts the active component when the plugin is destroyed. Both paths run the component's Svelte cleanup lifecycle.
+Internally, the adapter mounts a Svelte host component into the plugin container with `{ theme, devtoolsOpen, ...plugin.props }`. Repeated renders update that host's component and props, preserving the mounted plugin's state when its component identity is unchanged. The host is unmounted when the plugin is destroyed or the adapter shuts down, which runs the component's Svelte cleanup lifecycle.
 
 ### The Key Insight
 

--- a/docs/plugin-lifecycle.md
+++ b/docs/plugin-lifecycle.md
@@ -196,7 +196,7 @@ The Svelte adapter mounts the plugin component directly into the container and f
 <TanStackDevtools {plugins} />
 ```
 
-Internally, the adapter calls `mount(component, { target, props })` with `{ theme, devtoolsOpen, ...plugin.props }`. It calls `unmount()` when the plugin is destroyed, which runs the component's Svelte cleanup lifecycle.
+Internally, the adapter calls `mount(component, { target, props })` with `{ theme, devtoolsOpen, ...plugin.props }`. Before a repeated render, it unmounts the component associated with that container and then mounts the replacement. It also unmounts the active component when the plugin is destroyed. Both paths run the component's Svelte cleanup lifecycle.
 
 ### The Key Insight
 

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -88,6 +88,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.0.0",
     "@tanstack/devtools": "workspace:^",
     "svelte": "^5.0.0",
     "tsup": "^8.5.0",

--- a/packages/devtools-utils/src/svelte/DevtoolsPanel.svelte
+++ b/packages/devtools-utils/src/svelte/DevtoolsPanel.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import type { TanStackDevtoolsPluginProps } from '@tanstack/devtools'
+
+  interface Props {
+    CoreClass: new () => {
+      mount: (el: HTMLElement, props: TanStackDevtoolsPluginProps) => void
+      unmount: () => void
+    }
+    pluginProps: TanStackDevtoolsPluginProps
+  }
+
+  let { CoreClass, pluginProps }: Props = $props()
+
+  let hostEl: HTMLDivElement
+
+  onMount(() => {
+    const instance = new CoreClass()
+    instance.mount(hostEl, pluginProps)
+
+    return () => {
+      instance.unmount()
+    }
+  })
+</script>
+
+<div bind:this={hostEl} style="height: 100%"></div>

--- a/packages/devtools-utils/src/svelte/panel.test.ts
+++ b/packages/devtools-utils/src/svelte/panel.test.ts
@@ -9,12 +9,12 @@ vi.mock('svelte', () => ({ onDestroy }))
 function makeCoreClass() {
   const mount = vi.fn()
   const unmount = vi.fn()
-  const construct = vi.fn()
+  const construct = vi.fn<(...args: Array<unknown>) => void>()
   class Core {
     mount = mount
     unmount = unmount
-    constructor() {
-      construct()
+    constructor(...args: Array<unknown>) {
+      construct(...args)
     }
   }
   return { Core, construct, mount, unmount }
@@ -45,6 +45,7 @@ describe('createSveltePanel', () => {
     ;(Panel as any)(anchor, props)
 
     expect(construct).toHaveBeenCalledTimes(1)
+    expect(construct).toHaveBeenCalledWith()
     expect(mount).toHaveBeenCalledTimes(1)
     const call = mount.mock.calls[0]!
     const mountedEl = call[0] as HTMLElement

--- a/packages/devtools-utils/src/svelte/panel.test.ts
+++ b/packages/devtools-utils/src/svelte/panel.test.ts
@@ -1,28 +1,25 @@
+import { flushSync, mount as mountComponent, unmount } from 'svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSveltePanel } from './panel'
 
-const { onDestroy } = vi.hoisted(() => ({ onDestroy: vi.fn() }))
-
-vi.mock('svelte', () => ({ onDestroy }))
-
 // Minimal stand-in for a class-based devtools core.
 function makeCoreClass() {
-  const mount = vi.fn()
-  const unmount = vi.fn()
+  const coreMount = vi.fn()
+  const coreUnmount = vi.fn()
   const construct = vi.fn<(...args: Array<unknown>) => void>()
   class Core {
-    mount = mount
-    unmount = unmount
+    mount = coreMount
+    unmount = coreUnmount
     constructor(...args: Array<unknown>) {
       construct(...args)
     }
   }
-  return { Core, construct, mount, unmount }
+  return { Core, construct, coreMount, coreUnmount }
 }
 
 describe('createSveltePanel', () => {
   beforeEach(() => {
-    onDestroy.mockReset()
+    document.body.replaceChildren()
   })
 
   it('returns a [Panel, NoOpPanel] tuple of component functions', () => {
@@ -32,42 +29,48 @@ describe('createSveltePanel', () => {
     expect(typeof NoOpPanel).toBe('function')
   })
 
-  it('Panel constructs the core, mounts it with plugin props, and registers teardown', () => {
-    const { Core, construct, mount, unmount } = makeCoreClass()
+  it('Panel constructs the core, mounts it with plugin props, and tears it down', () => {
+    const { Core, construct, coreMount, coreUnmount } = makeCoreClass()
     const [Panel] = createSveltePanel(Core as any)
 
-    const anchor = document.createElement('span')
-    document.body.appendChild(anchor)
     const props = {
-      theme: 'dark',
+      theme: 'dark' as const,
       devtoolsOpen: true,
     }
-    ;(Panel as any)(anchor, props)
+    const component = mountComponent(Panel, {
+      target: document.body,
+      props,
+    })
+    flushSync()
 
     expect(construct).toHaveBeenCalledTimes(1)
     expect(construct).toHaveBeenCalledWith()
-    expect(mount).toHaveBeenCalledTimes(1)
-    const call = mount.mock.calls[0]!
+    expect(coreMount).toHaveBeenCalledTimes(1)
+    const call = coreMount.mock.calls[0]!
     const mountedEl = call[0] as HTMLElement
     expect(mountedEl).toBeInstanceOf(HTMLElement)
     expect(mountedEl.parentElement).toBe(document.body)
     expect(call[1]).toBe(props)
 
-    expect(onDestroy).toHaveBeenCalledTimes(1)
-    onDestroy.mock.calls[0]![0]()
-    expect(unmount).toHaveBeenCalledTimes(1)
-    expect(mountedEl.parentElement).toBeNull()
+    unmount(component)
 
-    anchor.remove()
+    expect(coreUnmount).toHaveBeenCalledTimes(1)
+    expect(mountedEl.parentElement).toBeNull()
   })
 
   it('NoOpPanel never constructs or mounts the core class', () => {
-    const { Core, construct, mount } = makeCoreClass()
+    const { Core, construct, coreMount } = makeCoreClass()
     const [, NoOpPanel] = createSveltePanel(Core as any)
-    const anchor = document.createElement('span')
-    ;(NoOpPanel as any)(anchor, { theme: 'dark', devtoolsOpen: true })
+    const component = mountComponent(NoOpPanel, {
+      target: document.body,
+      props: { theme: 'dark', devtoolsOpen: true },
+    })
+    flushSync()
+
     expect(construct).not.toHaveBeenCalled()
-    expect(mount).not.toHaveBeenCalled()
-    expect(onDestroy).not.toHaveBeenCalled()
+    expect(coreMount).not.toHaveBeenCalled()
+
+    unmount(component)
+    expect(document.body.children).toHaveLength(0)
   })
 })

--- a/packages/devtools-utils/src/svelte/panel.test.ts
+++ b/packages/devtools-utils/src/svelte/panel.test.ts
@@ -1,22 +1,30 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSveltePanel } from './panel'
+
+const { onDestroy } = vi.hoisted(() => ({ onDestroy: vi.fn() }))
+
+vi.mock('svelte', () => ({ onDestroy }))
 
 // Minimal stand-in for a class-based devtools core.
 function makeCoreClass() {
   const mount = vi.fn()
   const unmount = vi.fn()
-  let lastProps: unknown
+  const construct = vi.fn()
   class Core {
     mount = mount
     unmount = unmount
-    constructor(props: unknown) {
-      lastProps = props
+    constructor() {
+      construct()
     }
   }
-  return { Core, mount, unmount, getLastProps: () => lastProps }
+  return { Core, construct, mount, unmount }
 }
 
 describe('createSveltePanel', () => {
+  beforeEach(() => {
+    onDestroy.mockReset()
+  })
+
   it('returns a [Panel, NoOpPanel] tuple of component functions', () => {
     const { Core } = makeCoreClass()
     const [Panel, NoOpPanel] = createSveltePanel(Core as any)
@@ -24,30 +32,28 @@ describe('createSveltePanel', () => {
     expect(typeof NoOpPanel).toBe('function')
   })
 
-  it('Panel constructs the core with devtoolsProps, mounts it into a host element, and tears it down on destroy', () => {
-    const { Core, mount, unmount, getLastProps } = makeCoreClass()
+  it('Panel constructs the core, mounts it with plugin props, and registers teardown', () => {
+    const { Core, construct, mount, unmount } = makeCoreClass()
     const [Panel] = createSveltePanel(Core as any)
 
     const anchor = document.createElement('span')
     document.body.appendChild(anchor)
-
-    // Svelte 5 invokes a component with (anchor, props); the panel inserts its
-    // own host element before the anchor and mounts the core into it.
-    const instance = (Panel as any)(anchor, {
+    const props = {
       theme: 'dark',
-      devtoolsProps: { foo: 'bar' },
-    })
+      devtoolsOpen: true,
+    }
+    ;(Panel as any)(anchor, props)
 
-    expect(getLastProps()).toEqual({ foo: 'bar' })
+    expect(construct).toHaveBeenCalledTimes(1)
     expect(mount).toHaveBeenCalledTimes(1)
     const call = mount.mock.calls[0]!
     const mountedEl = call[0] as HTMLElement
-    const theme = call[1]
     expect(mountedEl).toBeInstanceOf(HTMLElement)
     expect(mountedEl.parentElement).toBe(document.body)
-    expect(theme).toBe('dark')
+    expect(call[1]).toBe(props)
 
-    instance.destroy()
+    expect(onDestroy).toHaveBeenCalledTimes(1)
+    onDestroy.mock.calls[0]![0]()
     expect(unmount).toHaveBeenCalledTimes(1)
     expect(mountedEl.parentElement).toBeNull()
 
@@ -55,10 +61,12 @@ describe('createSveltePanel', () => {
   })
 
   it('NoOpPanel never constructs or mounts the core class', () => {
-    const { Core, mount } = makeCoreClass()
+    const { Core, construct, mount } = makeCoreClass()
     const [, NoOpPanel] = createSveltePanel(Core as any)
     const anchor = document.createElement('span')
-    ;(NoOpPanel as any)(anchor, { theme: 'dark' })
+    ;(NoOpPanel as any)(anchor, { theme: 'dark', devtoolsOpen: true })
+    expect(construct).not.toHaveBeenCalled()
     expect(mount).not.toHaveBeenCalled()
+    expect(onDestroy).not.toHaveBeenCalled()
   })
 })

--- a/packages/devtools-utils/src/svelte/panel.ts
+++ b/packages/devtools-utils/src/svelte/panel.ts
@@ -1,35 +1,39 @@
+import { onDestroy } from 'svelte'
 import type { Component } from 'svelte'
+import type { TanStackDevtoolsPluginProps } from '@tanstack/devtools'
 
-export interface DevtoolsPanelProps {
-  theme?: 'dark' | 'light' | 'system'
-}
+export interface DevtoolsPanelProps extends TanStackDevtoolsPluginProps {}
 
 export function createSveltePanel<
   TComponentProps extends DevtoolsPanelProps,
   TCoreDevtoolsClass extends {
-    mount: (el: HTMLElement, theme?: DevtoolsPanelProps['theme']) => void
+    mount: (el: HTMLElement, props: TComponentProps) => void
     unmount: () => void
   },
 >(
-  CoreClass: new (props: TComponentProps) => TCoreDevtoolsClass,
-): [Component<any>, Component<any>] {
-  const Panel: Component<any> = ((anchor: any, props: any) => {
+  CoreClass: new () => TCoreDevtoolsClass,
+): [Component<TComponentProps>, Component<TComponentProps>] {
+  const Panel: Component<TComponentProps> = ((
+    anchor: any,
+    props: TComponentProps,
+  ) => {
     const el = document.createElement('div')
     el.style.height = '100%'
     anchor.before(el)
 
-    const instance = new CoreClass(props?.devtoolsProps as TComponentProps)
-    instance.mount(el, props?.theme)
+    const instance = new CoreClass()
+    instance.mount(el, props)
 
-    return {
-      destroy() {
-        instance.unmount()
-        el.remove()
-      },
-    }
-  }) as any
+    onDestroy(() => {
+      instance.unmount()
+      el.remove()
+    })
 
-  const NoOpPanel: Component<any> = (() => ({})) as any
+    return {}
+  }) as Component<TComponentProps>
+
+  const NoOpPanel: Component<TComponentProps> =
+    (() => ({})) as Component<TComponentProps>
 
   return [Panel, NoOpPanel]
 }

--- a/packages/devtools-utils/src/svelte/panel.ts
+++ b/packages/devtools-utils/src/svelte/panel.ts
@@ -1,4 +1,5 @@
-import { onDestroy } from 'svelte'
+import DevtoolsPanel from './DevtoolsPanel.svelte'
+import NoOp from './NoOp.svelte'
 import type { Component } from 'svelte'
 import type { TanStackDevtoolsPluginProps } from '@tanstack/devtools'
 
@@ -13,27 +14,11 @@ export function createSveltePanel<
 >(
   CoreClass: new () => TCoreDevtoolsClass,
 ): [Component<TComponentProps>, Component<TComponentProps>] {
-  const Panel: Component<TComponentProps> = ((
-    anchor: any,
-    props: TComponentProps,
-  ) => {
-    const el = document.createElement('div')
-    el.style.height = '100%'
-    anchor.before(el)
-
-    const instance = new CoreClass()
-    instance.mount(el, props)
-
-    onDestroy(() => {
-      instance.unmount()
-      el.remove()
+  const Panel: Component<TComponentProps> = (internals, props) =>
+    DevtoolsPanel(internals, {
+      CoreClass,
+      pluginProps: props,
     })
 
-    return {}
-  }) as Component<TComponentProps>
-
-  const NoOpPanel: Component<TComponentProps> =
-    (() => ({})) as Component<TComponentProps>
-
-  return [Panel, NoOpPanel]
+  return [Panel, NoOp]
 }

--- a/packages/devtools-utils/src/svelte/plugin.test.ts
+++ b/packages/devtools-utils/src/svelte/plugin.test.ts
@@ -4,39 +4,51 @@ import { createSveltePlugin } from './plugin'
 // A stand-in for a real Svelte component — createSveltePlugin only stores the
 // reference, it never mounts it, so an opaque function is sufficient here.
 const FakeComponent = vi.fn() as any
+const pluginConfig = {
+  Component: FakeComponent,
+  name: 'My Plugin',
+  id: 'my-plugin',
+  defaultOpen: true,
+}
 
 describe('createSveltePlugin', () => {
   it('returns a [Plugin, NoOpPlugin] tuple of factory functions', () => {
-    const result = createSveltePlugin('My Plugin', FakeComponent)
+    const result = createSveltePlugin(pluginConfig)
     expect(result).toHaveLength(2)
     const [Plugin, NoOpPlugin] = result
     expect(typeof Plugin).toBe('function')
     expect(typeof NoOpPlugin).toBe('function')
   })
 
-  it('Plugin() returns the name, the real component, and the forwarded props', () => {
-    const [Plugin] = createSveltePlugin('My Plugin', FakeComponent)
+  it('Plugin() returns the metadata, the real component, and the forwarded props', () => {
+    const [Plugin] = createSveltePlugin(pluginConfig)
     const props = { foo: 'bar' }
     expect(Plugin(props)).toEqual({
       name: 'My Plugin',
+      id: 'my-plugin',
+      defaultOpen: true,
       component: FakeComponent,
       props,
     })
   })
 
   it('Plugin() works when no props are supplied', () => {
-    const [Plugin] = createSveltePlugin('My Plugin', FakeComponent)
+    const [Plugin] = createSveltePlugin(pluginConfig)
     expect(Plugin()).toEqual({
       name: 'My Plugin',
+      id: 'my-plugin',
+      defaultOpen: true,
       component: FakeComponent,
       props: undefined,
     })
   })
 
-  it('NoOpPlugin() keeps the name but swaps in a no-op component (not the real one)', () => {
-    const [, NoOpPlugin] = createSveltePlugin('My Plugin', FakeComponent)
+  it('NoOpPlugin() keeps the metadata but swaps in a no-op component', () => {
+    const [, NoOpPlugin] = createSveltePlugin(pluginConfig)
     const noop = NoOpPlugin({ foo: 'bar' })
     expect(noop.name).toBe('My Plugin')
+    expect(noop.id).toBe('my-plugin')
+    expect(noop.defaultOpen).toBe(true)
     expect(noop.component).not.toBe(FakeComponent)
     expect(typeof noop.component).toBe('function')
     expect(noop.props).toEqual({ foo: 'bar' })

--- a/packages/devtools-utils/src/svelte/plugin.ts
+++ b/packages/devtools-utils/src/svelte/plugin.ts
@@ -1,20 +1,27 @@
 import type { Component } from 'svelte'
 
-export function createSveltePlugin<TComponentProps extends Record<string, any>>(
-  name: string,
-  component: Component<TComponentProps>,
-) {
+export function createSveltePlugin<
+  TComponentProps extends Record<string, any>,
+>({
+  Component,
+  ...config
+}: {
+  name: string
+  id?: string
+  defaultOpen?: boolean
+  Component: Component<TComponentProps>
+}) {
   function Plugin(props?: TComponentProps) {
     return {
-      name,
-      component,
+      ...config,
+      component: Component,
       props,
     }
   }
 
   function NoOpPlugin(props?: TComponentProps) {
     return {
-      name,
+      ...config,
       component: (() => {}) as unknown as Component<any>,
       props,
     }

--- a/packages/devtools-utils/src/svelte/plugin.ts
+++ b/packages/devtools-utils/src/svelte/plugin.ts
@@ -1,3 +1,4 @@
+import NoOp from './NoOp.svelte'
 import type { Component } from 'svelte'
 
 export function createSveltePlugin<
@@ -22,7 +23,7 @@ export function createSveltePlugin<
   function NoOpPlugin(props?: TComponentProps) {
     return {
       ...config,
-      component: (() => {}) as unknown as Component<any>,
+      component: NoOp,
       props,
     }
   }

--- a/packages/devtools-utils/svelte.config.js
+++ b/packages/devtools-utils/svelte.config.js
@@ -1,0 +1,8 @@
+/** @type {import('@sveltejs/vite-plugin-svelte').SvelteConfig} */
+const config = {
+  compilerOptions: {
+    runes: true,
+  },
+}
+
+export default config

--- a/packages/devtools-utils/vite.config.svelte.ts
+++ b/packages/devtools-utils/vite.config.svelte.ts
@@ -1,9 +1,10 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import packageJson from './package.json'
 
 const config = defineConfig({
-  plugins: [],
+  plugins: [svelte()],
   test: {
     name: packageJson.name,
     dir: './',

--- a/packages/devtools-utils/vite.config.ts
+++ b/packages/devtools-utils/vite.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import packageJson from './package.json'
 
 const config = defineConfig({
-  plugins: [],
+  plugins: process.env.VITEST === 'true' ? [svelte()] : [],
+  resolve:
+    process.env.VITEST === 'true' ? { conditions: ['browser'] } : undefined,
   test: {
     name: packageJson.name,
     dir: './',

--- a/packages/svelte-devtools/package.json
+++ b/packages/svelte-devtools/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "@tanstack/devtools-utils": "workspace:*",
     "svelte": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/svelte-devtools/package.json
+++ b/packages/svelte-devtools/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
-    "@tanstack/devtools-utils": "workspace:*",
     "svelte": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/svelte-devtools/src/ComponentHost.svelte
+++ b/packages/svelte-devtools/src/ComponentHost.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Component } from 'svelte'
+
+  interface Props {
+    component: Component<any>
+    componentProps: Record<string, unknown>
+  }
+
+  let {
+    component: CurrentComponent,
+    componentProps: currentComponentProps,
+  }: Props = $props()
+
+  export function update(
+    component: Component<any>,
+    componentProps: Record<string, unknown>,
+  ) {
+    CurrentComponent = component
+    currentComponentProps = componentProps
+  }
+</script>
+
+<CurrentComponent {...currentComponentProps} />

--- a/packages/svelte-devtools/src/devtools.svelte.ts
+++ b/packages/svelte-devtools/src/devtools.svelte.ts
@@ -1,5 +1,6 @@
 import { flushSync, mount, unmount } from 'svelte'
 import { TanStackDevtoolsCore } from '@tanstack/devtools'
+import ComponentHost from './ComponentHost.svelte'
 import type { Component } from 'svelte'
 import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
 import type {
@@ -7,7 +8,7 @@ import type {
   TanStackDevtoolsSveltePlugin,
 } from './types'
 
-type MountedComponent = ReturnType<typeof mount>
+type MountedComponent = ReturnType<typeof ComponentHost>
 
 export class TanStackDevtoolsSvelteAdapter {
   private devtools: TanStackDevtoolsCore | null = null
@@ -27,10 +28,6 @@ export class TanStackDevtoolsSvelteAdapter {
 
   update(init: TanStackDevtoolsSvelteInit) {
     if (this.devtools) {
-      // Tear down the previously mounted plugin components before re-applying
-      // config. The core re-invokes `render`/`name` for the new plugin set, so
-      // without this the old Svelte instances are orphaned and leak.
-      this.destroyAllComponents()
       this.devtools.setConfig({
         config: init.config,
         eventBusConfig: init.eventBusConfig,
@@ -95,11 +92,15 @@ export class TanStackDevtoolsSvelteAdapter {
     container: HTMLElement,
     props: Record<string, unknown>,
   ) {
-    this.destroyComponentInContainer(container)
+    const mounted = this.mountedComponents.get(container)
+    if (mounted) {
+      flushSync(() => mounted.update(component, props))
+      return
+    }
 
-    const instance = mount(component, {
+    const instance = mount(ComponentHost, {
       target: container,
-      props,
+      props: { component, componentProps: props },
     })
     this.mountedComponents.set(container, instance)
     flushSync()

--- a/packages/svelte-devtools/src/devtools.svelte.ts
+++ b/packages/svelte-devtools/src/devtools.svelte.ts
@@ -89,6 +89,8 @@ export class TanStackDevtoolsSvelteAdapter {
     container: HTMLElement,
     props: Record<string, unknown>,
   ) {
+    this.destroyComponentsInContainer(container.id)
+
     const instance = mount(component, {
       target: container,
       props,

--- a/packages/svelte-devtools/src/devtools.svelte.ts
+++ b/packages/svelte-devtools/src/devtools.svelte.ts
@@ -1,5 +1,5 @@
-import { mount, unmount } from 'svelte'
-import { PLUGIN_CONTAINER_ID, TanStackDevtoolsCore } from '@tanstack/devtools'
+import { flushSync, mount, unmount } from 'svelte'
+import { TanStackDevtoolsCore } from '@tanstack/devtools'
 import type { Component } from 'svelte'
 import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
 import type {
@@ -11,10 +11,7 @@ type MountedComponent = ReturnType<typeof mount>
 
 export class TanStackDevtoolsSvelteAdapter {
   private devtools: TanStackDevtoolsCore | null = null
-  private mountedComponents: Array<{
-    instance: MountedComponent
-    containerId: string
-  }> = []
+  private mountedComponents = new Map<HTMLElement, MountedComponent>()
 
   mount(target: HTMLElement, init: TanStackDevtoolsSvelteInit) {
     const pluginsMap = this.getPluginsMap(init.plugins)
@@ -60,6 +57,8 @@ export class TanStackDevtoolsSvelteAdapter {
   private convertPlugin(
     plugin: TanStackDevtoolsSveltePlugin,
   ): TanStackDevtoolsPlugin {
+    let panelContainer: HTMLElement | undefined
+
     return {
       id: plugin.id,
       defaultOpen: plugin.defaultOpen,
@@ -73,13 +72,20 @@ export class TanStackDevtoolsSvelteAdapter {
               })
             },
       render: (el, props) => {
+        if (panelContainer && panelContainer !== el) {
+          this.destroyComponentInContainer(panelContainer)
+        }
+        panelContainer = el
         this.renderComponent(plugin.component, el, {
           ...props,
           ...(plugin.props ?? {}),
         })
       },
-      destroy: (pluginId) => {
-        this.destroyComponentsInContainer(`${PLUGIN_CONTAINER_ID}-${pluginId}`)
+      destroy: () => {
+        if (panelContainer) {
+          this.destroyComponentInContainer(panelContainer)
+          panelContainer = undefined
+        }
       },
     }
   }
@@ -89,31 +95,29 @@ export class TanStackDevtoolsSvelteAdapter {
     container: HTMLElement,
     props: Record<string, unknown>,
   ) {
-    this.destroyComponentsInContainer(container.id)
+    this.destroyComponentInContainer(container)
 
     const instance = mount(component, {
       target: container,
       props,
     })
-
-    const containerId = container.id
-    this.mountedComponents.push({ instance, containerId })
+    this.mountedComponents.set(container, instance)
+    flushSync()
   }
 
-  private destroyComponentsInContainer(containerId: string) {
-    this.mountedComponents = this.mountedComponents.filter((entry) => {
-      if (entry.containerId === containerId) {
-        unmount(entry.instance)
-        return false
-      }
-      return true
-    })
+  private destroyComponentInContainer(container: HTMLElement) {
+    const instance = this.mountedComponents.get(container)
+    if (!instance) return
+
+    this.mountedComponents.delete(container)
+    unmount(instance)
   }
 
   private destroyAllComponents() {
-    for (const entry of this.mountedComponents) {
-      unmount(entry.instance)
+    const instances = [...this.mountedComponents.values()]
+    this.mountedComponents.clear()
+    for (const instance of instances) {
+      unmount(instance)
     }
-    this.mountedComponents = []
   }
 }

--- a/packages/svelte-devtools/src/devtools.svelte.ts
+++ b/packages/svelte-devtools/src/devtools.svelte.ts
@@ -66,15 +66,15 @@ export class TanStackDevtoolsSvelteAdapter {
       name:
         typeof plugin.name === 'string'
           ? plugin.name
-          : (el, theme) => {
+          : (el, props) => {
               this.renderComponent(plugin.name as Component<any>, el, {
-                theme,
+                ...props,
                 ...(plugin.props ?? {}),
               })
             },
-      render: (el, theme) => {
+      render: (el, props) => {
         this.renderComponent(plugin.component, el, {
-          theme,
+          ...props,
           ...(plugin.props ?? {}),
         })
       },

--- a/packages/svelte-devtools/tests/LifecyclePanel.svelte
+++ b/packages/svelte-devtools/tests/LifecyclePanel.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  interface Props {
+    devtoolsOpen: boolean
+    recordDestroy: () => void
+    recordMount: () => void
+    recordUpdate: (devtoolsOpen: boolean) => void
+  }
+
+  let { devtoolsOpen, recordDestroy, recordMount, recordUpdate }: Props =
+    $props()
+
+  onMount(() => {
+    recordMount()
+    return recordDestroy
+  })
+
+  $effect(() => {
+    recordUpdate(devtoolsOpen)
+  })
+</script>
+
+<div data-devtools-open={devtoolsOpen}></div>

--- a/packages/svelte-devtools/tests/devtools.test.ts
+++ b/packages/svelte-devtools/tests/devtools.test.ts
@@ -1,7 +1,6 @@
-import { onDestroy } from 'svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSveltePanel } from '@tanstack/devtools-utils/svelte'
 import { TanStackDevtoolsSvelteAdapter } from '../src/devtools.svelte'
-import type { Component } from 'svelte'
 import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
 
 const { capturePlugins } = vi.hoisted(() => ({ capturePlugins: vi.fn() }))
@@ -24,17 +23,13 @@ describe('TanStackDevtoolsSvelteAdapter', () => {
   })
 
   it('unmounts a panel before rendering its replacement', () => {
+    const coreMount = vi.fn()
     const coreUnmount = vi.fn()
-    const Panel = ((anchor: { before: (node: Node) => void }) => {
-      const shell = document.createElement('div')
-      shell.dataset.devtoolsShell = ''
-      anchor.before(shell)
-      onDestroy(() => {
-        coreUnmount()
-        shell.remove()
-      })
-      return {}
-    }) as unknown as Component
+    class PanelCore {
+      mount = coreMount
+      unmount = coreUnmount
+    }
+    const [Panel] = createSveltePanel(PanelCore)
 
     const adapter = new TanStackDevtoolsSvelteAdapter()
     adapter.mount(document.createElement('div'), {
@@ -44,15 +39,17 @@ describe('TanStackDevtoolsSvelteAdapter', () => {
     const plugins = capturePlugins.mock
       .calls[0]![0] as Array<TanStackDevtoolsPlugin>
     const container = document.createElement('div')
-    plugins[0]!.render(container, { theme: 'dark', devtoolsOpen: true })
-    plugins[0]!.render(container, { theme: 'dark', devtoolsOpen: false })
+    for (const devtoolsOpen of [true, false, true, false, true]) {
+      plugins[0]!.render(container, { theme: 'dark', devtoolsOpen })
+    }
 
-    expect(container.querySelectorAll('[data-devtools-shell]')).toHaveLength(1)
-    expect(coreUnmount).toHaveBeenCalledOnce()
+    expect(container.children).toHaveLength(1)
+    expect(coreMount).toHaveBeenCalledTimes(5)
+    expect(coreUnmount).toHaveBeenCalledTimes(4)
 
     adapter.destroy()
 
     expect(container.children).toHaveLength(0)
-    expect(coreUnmount).toHaveBeenCalledTimes(2)
+    expect(coreUnmount).toHaveBeenCalledTimes(5)
   })
 })

--- a/packages/svelte-devtools/tests/devtools.test.ts
+++ b/packages/svelte-devtools/tests/devtools.test.ts
@@ -1,0 +1,58 @@
+import { onDestroy } from 'svelte'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TanStackDevtoolsSvelteAdapter } from '../src/devtools.svelte'
+import type { Component } from 'svelte'
+import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
+
+const { capturePlugins } = vi.hoisted(() => ({ capturePlugins: vi.fn() }))
+
+vi.mock('@tanstack/devtools', () => ({
+  TanStackDevtoolsCore: class {
+    constructor(init: { plugins: Array<TanStackDevtoolsPlugin> }) {
+      capturePlugins(init.plugins)
+    }
+
+    mount() {}
+    setConfig() {}
+    unmount() {}
+  },
+}))
+
+describe('TanStackDevtoolsSvelteAdapter', () => {
+  beforeEach(() => {
+    capturePlugins.mockReset()
+  })
+
+  it('unmounts a panel before rendering its replacement', () => {
+    const coreUnmount = vi.fn()
+    const Panel = ((anchor: { before: (node: Node) => void }) => {
+      const shell = document.createElement('div')
+      shell.dataset.devtoolsShell = ''
+      anchor.before(shell)
+      onDestroy(() => {
+        coreUnmount()
+        shell.remove()
+      })
+      return {}
+    }) as unknown as Component
+
+    const adapter = new TanStackDevtoolsSvelteAdapter()
+    adapter.mount(document.createElement('div'), {
+      plugins: [{ id: 'test', name: 'Test', component: Panel }],
+    })
+
+    const plugins = capturePlugins.mock
+      .calls[0]![0] as Array<TanStackDevtoolsPlugin>
+    const container = document.createElement('div')
+    plugins[0]!.render(container, { theme: 'dark', devtoolsOpen: true })
+    plugins[0]!.render(container, { theme: 'dark', devtoolsOpen: false })
+
+    expect(container.querySelectorAll('[data-devtools-shell]')).toHaveLength(1)
+    expect(coreUnmount).toHaveBeenCalledOnce()
+
+    adapter.destroy()
+
+    expect(container.children).toHaveLength(0)
+    expect(coreUnmount).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/svelte-devtools/tests/devtools.test.ts
+++ b/packages/svelte-devtools/tests/devtools.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createSveltePanel } from '@tanstack/devtools-utils/svelte'
 import { TanStackDevtoolsSvelteAdapter } from '../src/devtools.svelte'
+import LifecyclePanel from './LifecyclePanel.svelte'
 import type { TanStackDevtoolsPlugin } from '@tanstack/devtools'
 
 const { capturePlugins } = vi.hoisted(() => ({ capturePlugins: vi.fn() }))
@@ -22,18 +22,20 @@ describe('TanStackDevtoolsSvelteAdapter', () => {
     capturePlugins.mockReset()
   })
 
-  it('unmounts a panel before rendering its replacement', () => {
-    const coreMount = vi.fn()
-    const coreUnmount = vi.fn()
-    class PanelCore {
-      mount = coreMount
-      unmount = coreUnmount
-    }
-    const [Panel] = createSveltePanel(PanelCore)
-
+  it('updates panel props without replacing the mounted component', () => {
+    const recordDestroy = vi.fn()
+    const recordMount = vi.fn()
+    const recordUpdate = vi.fn()
     const adapter = new TanStackDevtoolsSvelteAdapter()
     adapter.mount(document.createElement('div'), {
-      plugins: [{ id: 'test', name: 'Test', component: Panel }],
+      plugins: [
+        {
+          id: 'test',
+          name: 'Test',
+          component: LifecyclePanel,
+          props: { recordDestroy, recordMount, recordUpdate },
+        },
+      ],
     })
 
     const plugins = capturePlugins.mock
@@ -44,12 +46,25 @@ describe('TanStackDevtoolsSvelteAdapter', () => {
     }
 
     expect(container.children).toHaveLength(1)
-    expect(coreMount).toHaveBeenCalledTimes(5)
-    expect(coreUnmount).toHaveBeenCalledTimes(4)
+    expect(
+      container.firstElementChild?.getAttribute('data-devtools-open'),
+    ).toBe('true')
+    expect(recordMount).toHaveBeenCalledOnce()
+    expect(recordDestroy).not.toHaveBeenCalled()
+    expect(recordUpdate.mock.calls.map(([open]) => open)).toEqual([
+      true,
+      false,
+      true,
+      false,
+      true,
+    ])
 
-    adapter.destroy()
+    plugins[0]!.destroy?.('test')
 
     expect(container.children).toHaveLength(0)
-    expect(coreUnmount).toHaveBeenCalledTimes(5)
+    expect(recordDestroy).toHaveBeenCalledOnce()
+
+    adapter.destroy()
+    expect(recordDestroy).toHaveBeenCalledOnce()
   })
 })

--- a/packages/svelte-devtools/vite.config.ts
+++ b/packages/svelte-devtools/vite.config.ts
@@ -5,6 +5,8 @@ import packageJson from './package.json'
 
 const config = defineConfig({
   plugins: [svelte() as any],
+  resolve:
+    process.env.VITEST === 'true' ? { conditions: ['browser'] } : undefined,
   test: {
     name: packageJson.name,
     dir: './tests',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1826,9 +1826,6 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
         version: 6.2.4(svelte@5.55.1(@typescript-eslint/types@8.58.0))(vite@8.0.12(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@tanstack/devtools-utils':
-        specifier: workspace:*
-        version: link:../devtools-utils
       svelte:
         specifier: ^5.0.0
         version: 5.55.1(@typescript-eslint/types@8.58.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1694,6 +1694,9 @@ importers:
         specifier: '>=3.2.0'
         version: 3.5.34(typescript@5.9.3)
     devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^6.0.0
+        version: 6.2.4(svelte@5.55.1(@typescript-eslint/types@8.58.0))(vite@8.0.12(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/devtools':
         specifier: workspace:^
         version: link:../devtools
@@ -1823,6 +1826,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
         version: 6.2.4(svelte@5.55.1(@typescript-eslint/types@8.58.0))(vite@8.0.12(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/devtools-utils':
+        specifier: workspace:*
+        version: link:../devtools-utils
       svelte:
         specifier: ^5.0.0
         version: 5.55.1(@typescript-eslint/types@8.58.0)


### PR DESCRIPTION
Closes #503

## 🎯 Changes

- Align `createSveltePanel` with the shared core contract: `new CoreClass()` followed by `mount(element, pluginProps)`.

- Use compiled Svelte components to own panel, core, and no-op lifecycles instead of relying on hand-authored component-shaped functions.

- Align `createSveltePlugin` with the other framework factories by accepting `{ Component, name, id, defaultOpen }`.

- Forward complete `{ theme, devtoolsOpen, ...plugin.props }` values through the Svelte adapter.

- Mount one compiled Svelte host per plugin container and update its component and props on repeated renders, preserving state while the component identity remains unchanged.

- Unmount plugin hosts only when a plugin closes, moves to a different container, or the adapter shuts down.

- Add real Svelte runtime regressions covering prop updates without remounting, plugin teardown, and final adapter cleanup.

- Configure the mixed-framework utilities package to compile Svelte sources in its dedicated build and shared tests, with package-wide runes mode.

- Update Svelte factory and lifecycle documentation for the unified contracts and state-preserving render behavior.

- Add changesets for `@tanstack/devtools-utils` and `@tanstack/svelte-devtools`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Svelte integrations now forward theme, open-state, and plugin-specific props to components.
  - Existing Svelte components update in place, preserving state during prop changes.
  - Added reliable mounting, replacement, and cleanup behavior for Svelte panels and plugins.
  - Svelte plugin configuration now supports metadata such as IDs and default-open settings.

- **Documentation**
  - Updated React, Svelte, and Angular integration guidance.
  - Documented shared plugin properties, lifecycle behavior, mounting APIs, and cleanup processes.

- **Bug Fixes**
  - Prevented duplicate mounting and unmounting during panel updates and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
