### PR TITLE
fix(devtools): install Neodrag core dependency

### DIFF
--- a/.changeset/kind-tools-drag.md
+++ b/.changeset/kind-tools-drag.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/devtools': patch
+---
+
+Install Neodrag's required core peer dependency so consumers do not need to add it themselves.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -67,6 +67,7 @@
     "build": "tsup"
   },
   "dependencies": {
+    "@neodrag/core": "3.0.0-next.11",
     "@neodrag/solid": "3.0.0-next.11",
     "@solid-primitives/event-listener": "^2.4.3",
     "@solid-primitives/keyboard": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,6 +1514,9 @@ importers:
 
   packages/devtools:
     dependencies:
+      '@neodrag/core':
+        specifier: 3.0.0-next.11
+        version: 3.0.0-next.11
       '@neodrag/solid':
         specifier: 3.0.0-next.11
         version: 3.0.0-next.11(@neodrag/core@3.0.0-next.11)(solid-js@1.9.12)


### PR DESCRIPTION
`@tanstack/devtools` uses `@neodrag/solid`, whose sortable entry imports its required `@neodrag/core` peer. Consumers that disable peer auto-installation therefore receive an incomplete runtime dependency graph and fail to bundle `@tanstack/react-devtools`.

This adds the matching `@neodrag/core@3.0.0-next.11` version as a direct runtime dependency, updates the lockfile, and adds a patch changeset.

Reproduction: https://codesandbox.io/p/devbox/starter-vite-react-forked-nqxz57

Verification:
- `nx run @tanstack/devtools:test:types`
- `nx run @tanstack/devtools:test:eslint`
- `nx run @tanstack/devtools:test:lib` (323 tests)
- `nx run @tanstack/devtools:build`
- `nx run @tanstack/devtools:test:build`
- packed `@tanstack/devtools` into a fresh pnpm consumer with `autoInstallPeers: false`; install and Vite build pass

Fixes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Devtools installation by including a required dependency for drag-and-drop functionality.
  * Added a patch release note documenting the dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->