### PR TITLE
fix(devtools): keep plugin bar fold across late plugin registration

### DIFF
--- a/.changeset/keep-strip-fold-late-plugins.md
+++ b/.changeset/keep-strip-fold-late-plugins.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/devtools": patch
+---
+
+Keep the folded plugin strip across late plugin registration so a persisted fold is not force-expanded on reload.

--- a/packages/devtools/src/components/plugins-strip.tsx
+++ b/packages/devtools/src/components/plugins-strip.tsx
@@ -94,7 +94,7 @@ export const PluginsStrip = (props: { isOpen: Accessor<boolean> }) => {
    * The first run only seeds the previous emptiness — it must not drive collapse.
    * Plugins often register after mount (`setConfig` / `onSetPlugins`), and treating
    * that empty→available jump as "a plugin returned" would force-expand a fold the
-   * user persisted across reload (#505).
+   * user persisted across reload (issue 505).
    *
    * Auto-expand is also gated on having already seen a non-empty strip *or*
    * registered plugins on the first snapshot (everything open → available empty,

--- a/packages/devtools/src/components/plugins-strip.tsx
+++ b/packages/devtools/src/components/plugins-strip.tsx
@@ -90,13 +90,39 @@ export const PluginsStrip = (props: { isOpen: Accessor<boolean> }) => {
    * Fold the strip away once everything is open, and bring it back the moment a
    * plugin closes and returns to it. Only those two transitions are automatic, so
    * a deliberate fold or unfold in between is left alone.
+   *
+   * The first run only seeds the previous emptiness — it must not drive collapse.
+   * Plugins often register after mount (`setConfig` / `onSetPlugins`), and treating
+   * that empty→available jump as "a plugin returned" would force-expand a fold the
+   * user persisted across reload (#505).
+   *
+   * Auto-expand is also gated on having already seen a non-empty strip *or*
+   * registered plugins on the first snapshot (everything open → available empty,
+   * but plugins exist). That keeps "close one pane → strip comes back" after a
+   * remount, without unlocking the late-registration path above.
    */
-  createEffect((wasEmpty: boolean | undefined) => {
-    const isEmpty = available().length === 0
-    if (isEmpty && wasEmpty === false) setCollapsed(true)
-    if (!isEmpty && wasEmpty === true) setCollapsed(false)
-    return isEmpty
-  })
+  createEffect(
+    (
+      previous:
+        | { wasEmpty: boolean; mayAutoExpand: boolean }
+        | undefined,
+    ) => {
+      const isEmpty = available().length === 0
+      const mayAutoExpand =
+        Boolean(previous?.mayAutoExpand) ||
+        !isEmpty ||
+        (plugins() ?? []).length > 0
+
+      if (previous) {
+        if (isEmpty && !previous.wasEmpty) setCollapsed(true)
+        if (!isEmpty && previous.wasEmpty && previous.mayAutoExpand) {
+          setCollapsed(false)
+        }
+      }
+
+      return { wasEmpty: isEmpty, mayAutoExpand }
+    },
+  )
 
   return (
     <WorkbenchSecondaryTabs

--- a/packages/devtools/tests/workbench.test.tsx
+++ b/packages/devtools/tests/workbench.test.tsx
@@ -562,6 +562,78 @@ describe('workbench', { timeout: 30_000 }, () => {
     ).toHaveAttribute('data-subheader-collapsed', 'true')
   })
 
+  it('keeps a persisted fold when plugins register after mount', async () => {
+    localStorage.setItem(
+      TANSTACK_DEVTOOLS_STATE,
+      JSON.stringify({
+        activeTab: 'plugins',
+        height: 400,
+        persistOpen: true,
+        subheaderCollapsed: true,
+        layout: null,
+      }),
+    )
+
+    let setPlugins:
+      | ((plugins: Array<TanStackDevtoolsPlugin>) => void)
+      | undefined
+    const host = document.body.appendChild(document.createElement('div'))
+    const dispose = render(
+      () =>
+        createComponent(DevtoolsProvider, {
+          plugins: [],
+          config: { defaultOpen: true } as TanStackDevtoolsConfig,
+          onSetPlugins: (setter) => {
+            setPlugins = setter
+          },
+          get children() {
+            return createComponent(PiPProvider, {
+              get children() {
+                return createComponent(DevTools, {})
+              },
+            })
+          },
+        }),
+      host,
+    )
+    disposers.push(dispose)
+
+    const panel = () =>
+      document.querySelector('[data-testid="tanstack-devtools-panel"]')!
+
+    expect(panel()).toHaveAttribute('data-subheader-collapsed', 'true')
+
+    setPlugins!([plugin('one'), plugin('two')])
+    await Promise.resolve()
+
+    // Late registration used to look like "a plugin returned to the strip" and
+    // force-expand a fold restored from localStorage (#505).
+    expect(panel()).toHaveAttribute('data-subheader-collapsed', 'true')
+    expect(
+      JSON.parse(localStorage.getItem(TANSTACK_DEVTOOLS_STATE)!)
+        .subheaderCollapsed,
+    ).toBe(true)
+  })
+
+  it('still unfolds the strip when a pane closes after everything was open', async () => {
+    mountWorkbench([plugin('one'), plugin('two')])
+    await Promise.resolve()
+
+    // Open both so the strip becomes empty and auto-folds.
+    click('Plugin one')
+    click('Plugin two')
+    const panel = document.querySelector(
+      '[data-testid="tanstack-devtools-panel"]',
+    )!
+    expect(panel).toHaveAttribute('data-subheader-collapsed', 'true')
+
+    closePane('one')
+    expect(panel).toHaveAttribute('data-subheader-collapsed', 'false')
+    expect(
+      document.querySelector('[data-testid="plugins-strip"]'),
+    ).not.toHaveAttribute('data-collapsed')
+  })
+
   it.each([
     ['bottom', 'ArrowUp', 410],
     ['bottom', 'ArrowDown', 390],

--- a/packages/devtools/tests/workbench.test.tsx
+++ b/packages/devtools/tests/workbench.test.tsx
@@ -607,7 +607,7 @@ describe('workbench', { timeout: 30_000 }, () => {
     await Promise.resolve()
 
     // Late registration used to look like "a plugin returned to the strip" and
-    // force-expand a fold restored from localStorage (#505).
+    // force-expand a fold restored from localStorage (issue 505).
     expect(panel()).toHaveAttribute('data-subheader-collapsed', 'true')
     expect(
       JSON.parse(localStorage.getItem(TANSTACK_DEVTOOLS_STATE)!)


### PR DESCRIPTION
## 🎯 Changes

Fixes #505.

The plugins strip auto-expands when it goes from empty → non-empty. Plugins often register after mount (`setConfig` / `onSetPlugins`), so that transition looked like “a plugin returned” and force-expanded a fold restored from `localStorage`.

- Seed the emptiness snapshot on the first effect run without driving collapse
- Only auto-expand after the strip has already been non-empty in-session (or plugins were already registered while available was empty)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/devtools/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).